### PR TITLE
feat(adaptive): node lifecycle + warmup + measured mesh bench

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -11,6 +11,43 @@
 
 ---
 
+## Measured results so far
+
+All numbers here are observed on a real cluster, not projections.
+
+### Mesh-adaptation experiment (2 workers on the same Mac, HTTP transport, 100 dispatches per stage, `scripts/bench_mesh_adaptation.py`)
+
+**Greedy argmin (`softmax_temperature=0`):**
+
+| stage | wall | worker 0 picks | worker 1 picks | observation |
+|---|---|---|---|---|
+| warmup | — | — | — | p95: `19 ms`, `16 ms`; recommended `backpressure_threshold = 0.029 s` |
+| after warmup | 1.63 s | 0 (0 %) | 100 (100 %) | Greedy commits fully to the 3 ms-faster worker. |
+| remove worker 0 | 1.69 s | — | 100 (100 %) | Traffic trivially rebalances to the survivor. |
+| readmit worker 0 | 1.61 s | 91 (91 %) | 9 (9 %) | Readmitted worker bootstrap-seeded at 17.1 ms; wins most traffic because it beats worker 1's running EMA. |
+
+**Softmax (`softmax_temperature=0.01`):**
+
+| stage | worker 0 picks | worker 1 picks | observation |
+|---|---|---|---|
+| after warmup | 60 (60 %) | 40 (40 %) | Soft routing keeps both workers utilised. |
+| readmit worker 0 | 44 (44 %) | 56 (56 %) | Rebalances within a single batch of 100. |
+
+### Sakura BERT benchmark (x399 4090 trains, Mac MPS evals, distilbert SST-2, 15 epochs)
+
+Repeated from the PR history for context — also measured, also observed:
+
+| configuration | serial | async | Δ |
+|---|---|---|---|
+| pre-improvements (zakuro 0.2.2) | 9.49 s | 60.91 s | −549 % |
+| + perf patches (`sakura#36`) | 9.49 s | 33.51 s | −253 % |
+| + `AdaptiveCompute` + `bp=1` | 18.39 s | 20.40 s | −11 % |
+| adaptive, all skips (framework floor) | 18.39 s | **15.80 s** | **+12 %** |
+
+The current `warmup()` would have produced `bp ≈ 0.03 × eval-size-ratio` automatically instead of the hand-tuned `1.0 s` that got us the last row; a follow-up measurement against that hardware is queued.
+
+---
+
 ## Phase 0 — Ground state (complete)
 
 The framework floor as of 0.2.3.
@@ -30,11 +67,11 @@ The framework floor as of 0.2.3.
 
 ---
 
-## Phase 1 — Mesh awareness (next)
+## Phase 1 — Mesh awareness (in progress)
 
 **Goal:** the allocator reacts to grid changes within seconds.
 
-### 1.1 Health-aware dispatch — F3.5 🔜
+### 1.1 Health-aware dispatch — F3.5 🚧
 
 - Add a heartbeat loop on `AdaptiveCompute` that polls each worker's `HEALTH` opcode every N seconds. Low priority, coalesced into a single stream per worker.
 - On failed / slow heartbeat, raise that worker's effective latency by a penalty factor (e.g. `×10`) without permanently marking it dead. A single missed probe should not kill a worker.
@@ -50,11 +87,12 @@ The framework floor as of 0.2.3.
 - Use the variance EMA (already tracked) as the threshold signal: `m_hat + 3 × sqrt(v_hat)`.
 - Recovery rule: two consecutive dispatches below the historical median → un-demote.
 
-### 1.3 Node admission / departure API — F4.2, F4.3 🔜
+### 1.3 Node admission / departure API — F4.2, F4.3 ✅
 
 - `AdaptiveCompute.add_worker(compute)` / `.remove_worker(idx)` — thread-safe mutation of the pool.
-- New workers receive a bootstrap prior from mesh-median latency rather than the static `initial_latency` default.
+- New workers receive a bootstrap prior from mesh-median latency rather than the static `initial_latency` default. Seeded as `m = median × (1 − β₁)` so that the bias-corrected `m̂` *equals* the median on step 1.
 - Hook for a future discovery source (`Tailscale peer list`, `K8s service endpoints`, etc.) to push changes.
+- Refuses to drop the last worker — returns `ValueError("cannot remove the last worker; add a replacement first")`.
 
 ### 1.4 QUIC connection migration — F4.2 💭
 
@@ -68,25 +106,32 @@ The framework floor as of 0.2.3.
 
 **Goal:** every training run starts with calibrated per-worker priors.
 
-### 2.1 `AdaptiveCompute.warmup(duration=2s)` — F4.1 🔜
+### 2.1 `AdaptiveCompute.warmup(rounds=3, timeout=10s)` — F4.1 ✅
 
-Runs three probes per worker in round-robin:
+Runs `rounds` successful EXECUTE round-trips per worker against a cheap
+identity probe. Observed latencies seed each worker's EMA, replacing the
+pessimistic `initial_latency` bootstrap; workers that fail every probe
+inside `timeout` are ejected from the pool.
 
-1. **Liveness** — HEALTH opcode. Confirms worker responds.
-2. **Roundtrip** — EXECUTE a trivial 1-byte payload. Measures network RTT + framing.
-3. **Throughput** — EXECUTE a 1 MiB payload and a pickle-heavy object. Measures bandwidth + dispatch overhead.
+- `recommended_backpressure = 1.5 × max(observed_worker_p95)`.
+- Workers that respond get their stats re-initialised with `(m=mean_latency, step=rounds)` so post-warmup routing is backed by real observations from the first dispatch.
+- `eject_on_failure=True` drops unreachable peers before real traffic lands.
 
-Outputs:
-- Initial `m` seeded with observed latency (no more pessimistic `initial_latency=1.0` guess).
-- Failed-probe workers ejected before training starts.
-- `recommended_backpressure` = worst observed per-worker p95 × 1.5.
+Measured example (two zakuro-worker processes on the same Mac, HTTP transport):
 
-Reports a one-line summary to stderr:
-
+```text
+[warmup] zakuro://127.0.0.1:58332 (p95=0.019s),
+         zakuro://127.0.0.1:58335 (p95=0.016s)
+[warmup] recommended backpressure: 0.03s
 ```
-[warmup] 4 workers: mac (0.32s), x399-a (0.04s), x399-b (0.04s), mac-b: EJECTED (timeout)
-[warmup] recommended backpressure: 0.8s
-```
+
+The 30 ms threshold is ~1.5× the slower worker's p95, i.e. the number
+`SakuraHFCallback(backpressure_threshold=...)` used to take as a hand-tuned
+argument now gets derived from observation.
+
+The richer liveness/bandwidth probes listed in the original plan are
+future-work; the current warmup uses a single probe shape that's sufficient
+to seed priors and detect dead nodes.
 
 ### 2.2 CLI command `zc bench mesh` 💭
 

--- a/scripts/bench_mesh_adaptation.py
+++ b/scripts/bench_mesh_adaptation.py
@@ -1,0 +1,195 @@
+"""Measured-only mesh experiments on a real 2-worker cluster.
+
+Every number this script prints is observed, not simulated. Run:
+
+    uv run python scripts/bench_mesh_adaptation.py --n-workers 2 --dispatch 100
+
+The script spawns N zakuro-worker subprocesses (via ``zk.Worker.spawn``),
+builds an ``AdaptiveCompute`` over them, and walks through four checkpoints,
+printing the real measured behaviour:
+
+    1. warmup            → per-worker p95 + ejection decision + BP recommend
+    2. dispatch N tasks  → allocation histogram across workers
+    3. remove_worker(0)  → dispatch N more → verify all traffic shifts
+    4. add_worker back   → dispatch N more → verify traffic rebalances
+
+The logs go both to stdout and to ``--log results.json`` for later analysis.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import statistics
+import time
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+import zakuro as zk
+
+
+def _slow_task(n: int = 50_000) -> int:
+    """A deterministic CPU-bound chunk — ~1 ms on a modern core.
+
+    Kept small and pure so cloudpickle dispatches cheaply; the goal is to
+    observe routing behaviour, not to measure compute throughput.
+    """
+    acc = 0
+    for i in range(n):
+        acc = (acc + i * 7919) % (10**9 + 7)
+    return acc
+
+
+def _dispatch_round(
+    fn: Any,
+    adaptive: zk.AdaptiveCompute,
+    count: int,
+    label: str,
+) -> dict[str, Any]:
+    """Send ``count`` tasks through the allocator and return a measured summary."""
+    latencies: list[float] = []
+    picks: list[int] = []
+
+    # We don't know in advance which worker gets picked — AdaptiveCompute
+    # records stats via dispatch(), so we can read picks from stats() delta.
+    before_steps = [s["step"] for s in adaptive.stats()]
+    t0 = time.perf_counter()
+    for _ in range(count):
+        a0 = time.perf_counter()
+        fn.to(adaptive)()
+        latencies.append(time.perf_counter() - a0)
+    total = time.perf_counter() - t0
+    after_steps = [s["step"] for s in adaptive.stats()]
+    picks_delta = [a - b for a, b in zip(after_steps, before_steps)]
+
+    summary = {
+        "label": label,
+        "count": count,
+        "wall_secs": total,
+        "per_worker_picks": picks_delta,
+        "latency_median_ms": 1000.0 * statistics.median(latencies) if latencies else 0.0,
+        "latency_p95_ms": (
+            1000.0 * sorted(latencies)[int(0.95 * len(latencies))]
+            if len(latencies) >= 5 else 0.0
+        ),
+        "worker_stats": adaptive.stats(),
+    }
+    return summary
+
+
+def _print_summary(summary: dict[str, Any]) -> None:
+    print(f"\n--- {summary['label']} ---")
+    print(
+        f"  {summary['count']} dispatches in {summary['wall_secs']:.2f}s  "
+        f"(median {summary['latency_median_ms']:.1f}ms, "
+        f"p95 {summary['latency_p95_ms']:.1f}ms)"
+    )
+    print("  pick distribution:")
+    for i, n in enumerate(summary["per_worker_picks"]):
+        pct = 100 * n / summary["count"] if summary["count"] else 0
+        s = summary["worker_stats"][i]
+        print(
+            f"    worker {i}: {n:>4} picks ({pct:>5.1f}%)  "
+            f"ema={s['latency_ema']*1000:.1f}ms  queue={s['queue']}  "
+            f"failures={s['failures']}"
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--n-workers", type=int, default=2)
+    parser.add_argument(
+        "--dispatch",
+        type=int,
+        default=100,
+        help="Dispatches per checkpoint.",
+    )
+    parser.add_argument(
+        "--transport",
+        choices=("http", "quic"),
+        default="http",
+        help="Transport for spawned workers. HTTP is more portable; QUIC "
+             "needs the [worker] extra installed.",
+    )
+    parser.add_argument("--seed", type=int, default=7)
+    parser.add_argument(
+        "--softmax-temperature",
+        type=float,
+        default=0.0,
+        help="0 = greedy argmin; >0 enables probabilistic routing.",
+    )
+    parser.add_argument("--log", default=None, help="Write JSON results to this path.")
+    args = parser.parse_args()
+
+    random.seed(args.seed)
+    results: dict[str, Any] = {
+        "n_workers": args.n_workers,
+        "dispatch": args.dispatch,
+        "transport": args.transport,
+        "stages": [],
+    }
+
+    # -------------------- spawn workers --------------------
+    workers = [
+        zk.Worker.spawn(name=f"bench-{i}", transport=args.transport)
+        for i in range(args.n_workers)
+    ]
+    print(f"Spawned {len(workers)} workers: {[w.uri for w in workers]}")
+
+    adaptive = zk.AdaptiveCompute(
+        workers=[w.compute(verify=False) for w in workers],
+        beta1=0.8,
+        beta2=0.99,
+        initial_latency=0.5,
+        backpressure_threshold=999.0,
+        softmax_temperature=args.softmax_temperature,
+    )
+    results["softmax_temperature"] = args.softmax_temperature
+
+    # A zk.fn dispatched across the allocator.
+    slow = zk.fn(_slow_task)
+
+    try:
+        # -------------------- 1. warmup --------------------
+        print("\n=== 1. warmup ===")
+        warmup_report = adaptive.warmup(rounds=3, timeout=5.0, verbose=True)
+        results["warmup"] = warmup_report
+        print(f"  (allocator.backpressure_threshold = "
+              f"{adaptive.backpressure_threshold:.3f}s)")
+
+        # -------------------- 2. dispatch N tasks --------------------
+        s1 = _dispatch_round(slow, adaptive, args.dispatch, "after warmup")
+        _print_summary(s1)
+        results["stages"].append(s1)
+
+        # -------------------- 3. remove worker 0, dispatch again --------------
+        print("\n=== 3. remove worker 0 (node departure) ===")
+        removed = adaptive.remove_worker(0)
+        print(f"  removed: {removed.uri}")
+        print(f"  remaining workers: {[w.uri for w in adaptive.workers]}")
+        s2 = _dispatch_round(slow, adaptive, args.dispatch, "after removal")
+        _print_summary(s2)
+        results["stages"].append(s2)
+
+        # -------------------- 4. readmit, dispatch again ---------------------
+        print("\n=== 4. readmit the worker (node admission) ===")
+        new_idx = adaptive.add_worker(workers[0].compute(verify=False))
+        print(f"  readmitted at idx {new_idx}, "
+              f"seeded ema = {adaptive.stats()[new_idx]['latency_ema']*1000:.1f}ms")
+        s3 = _dispatch_round(slow, adaptive, args.dispatch, "after readmission")
+        _print_summary(s3)
+        results["stages"].append(s3)
+
+    finally:
+        for w in workers:
+            w.stop()
+
+    if args.log:
+        Path(args.log).write_text(json.dumps(results, indent=2, default=float))
+        print(f"\nresults written to {args.log}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_adaptive.py
+++ b/tests/test_adaptive.py
@@ -113,6 +113,86 @@ class TestBackpressure:
         assert ac.is_backpressured()
 
 
+class TestNodeLifecycle:
+    def test_add_worker_seeds_with_mesh_median(self) -> None:
+        """A new worker's EMA should start at the mesh median, not at zero."""
+        ac = AdaptiveCompute(
+            workers=[_fast_worker(), _slow_worker()],
+            beta1=0.9,
+            initial_latency=5.0,
+        )
+        for _ in range(30):
+            ac._update_ema(ac._stats[0], 0.5)
+            ac._update_ema(ac._stats[1], 1.5)
+        # Median of {~0.5, ~1.5} ≈ 1.0.
+        new_idx = ac.add_worker(Compute(host="newcomer.local", verify=False))
+        stats = ac.stats()[new_idx]
+        assert 0.4 < stats["latency_ema"] < 2.0
+
+    def test_remove_worker(self) -> None:
+        ac = AdaptiveCompute(
+            workers=[_fast_worker(), _slow_worker()],
+        )
+        dropped = ac.remove_worker(0)
+        assert dropped.host == "fast.local"
+        assert len(ac.workers) == 1
+
+    def test_cannot_remove_last_worker(self) -> None:
+        ac = AdaptiveCompute(workers=[_fast_worker()])
+        with pytest.raises(ValueError, match="last worker"):
+            ac.remove_worker(0)
+
+
+class TestWarmup:
+    def test_warmup_seeds_stats(self) -> None:
+        """warmup should run probes and update per-worker EMAs."""
+        # Single-worker adaptive; the worker has no URI/host → standalone
+        # fallback runs the probe in-process (fast + reliable for tests).
+        ac = AdaptiveCompute(
+            workers=[Compute(cpus=1)],
+            initial_latency=10.0,  # deliberately bad prior to see warmup fix it
+        )
+        with patch("zakuro.standalone.detect_backend", return_value=None):
+            report = ac.warmup(rounds=3, timeout=5.0, verbose=False)
+
+        assert report["workers"][0]["ok"]
+        assert report["workers"][0]["rounds_succeeded"] == 3
+        # Stats are seeded from real measurements, not the 10.0 bootstrap.
+        assert ac.stats()[0]["step"] == 3
+        assert ac.stats()[0]["latency_ema"] < 1.0
+
+    def test_warmup_sets_backpressure_from_p95(self) -> None:
+        ac = AdaptiveCompute(
+            workers=[Compute(cpus=1)],
+            backpressure_threshold=999.0,
+        )
+        with patch("zakuro.standalone.detect_backend", return_value=None):
+            report = ac.warmup(rounds=4, verbose=False)
+        assert report["applied_backpressure"] is True
+        # Should now be ~1.5× observed p95, not the 999 we started with.
+        assert ac.backpressure_threshold < 5.0
+        assert (
+            abs(ac.backpressure_threshold - 1.5 * report["workers"][0]["latency_p95"])
+            < 1e-6
+        )
+
+    def test_warmup_ejects_unreachable_worker(self) -> None:
+        """A worker whose probe raises every round should be dropped."""
+        good = Compute(cpus=1)  # standalone-ok
+        # Bad worker: explicit URI → verify at construction probe-reachable
+        # won't match (unroutable). Use verify=False to delay the failure to
+        # the warmup probe itself.
+        bad = Compute(uri="quic://192.0.2.1:4444", verify=False)
+        ac = AdaptiveCompute(workers=[good, bad])
+
+        with patch("zakuro.standalone.detect_backend", return_value=None):
+            report = ac.warmup(rounds=2, timeout=2.0, verbose=False)
+        # good remains; bad gets ejected.
+        assert len(ac.workers) == 1
+        assert report["ejected"] == [1]
+        assert any(r["ok"] is False for r in report["workers"])
+
+
 class TestDispatch:
     def test_dispatch_times_and_records(self) -> None:
         """AdaptiveCompute.dispatch should run the fn and update stats."""

--- a/zakuro/adaptive.py
+++ b/zakuro/adaptive.py
@@ -54,6 +54,22 @@ if TYPE_CHECKING:
     from zakuro.compute import Compute
 
 
+def _identity(x: Any) -> Any:
+    """Module-level identity used as the default warmup probe.
+
+    Kept at module scope so it cloudpickles cleanly on the worker side
+    (local / lambda functions don't) and so subsequent calls reuse the
+    worker-side module cache.
+    """
+    return x
+
+
+# Small sentinel passed as the probe argument.  Empty string keeps the payload
+# under a dozen bytes so warmup latency is dominated by network RTT rather
+# than transfer.
+_WARMUP_TOKEN = ""
+
+
 class _WorkerStats:
     """Per-worker running statistics in the Adam style.
 
@@ -162,7 +178,19 @@ class AdaptiveCompute:
     @property
     def workers(self) -> list["Compute"]:
         """Read-only view of the worker pool."""
-        return list(self._workers)
+        with self._lock:
+            return list(self._workers)
+
+    @property
+    def backpressure_threshold(self) -> float:
+        """Current backpressure cap, in seconds."""
+        return self._backpressure
+
+    @backpressure_threshold.setter
+    def backpressure_threshold(self, value: float) -> None:
+        if value < 0:
+            raise ValueError("backpressure_threshold must be non-negative")
+        self._backpressure = float(value)
 
     def stats(self) -> list[dict[str, Any]]:
         """Snapshot of per-worker stats, bias-corrected."""
@@ -182,6 +210,209 @@ class AdaptiveCompute:
         """
         with self._lock:
             return self._pick_locked()
+
+    # ........................................................ node lifecycle
+
+    def add_worker(self, compute: "Compute") -> int:
+        """Admit a new worker into the pool. Returns its index.
+
+        The fresh worker is seeded with a bootstrap latency prior equal to
+        the current mesh-median observed latency — this prevents "greedy
+        stampede" onto a new (unverified) worker before it proves itself,
+        while still letting it earn traffic on its first observation.
+        """
+        with self._lock:
+            median = self._mesh_median_latency_locked()
+            self._workers.append(compute)
+            new_stats = _WorkerStats()
+            # Seed the EMA so the *bias-corrected* m_hat equals the mesh
+            # median. m_hat = m / (1 − β₁^step); solving for m with step=1
+            # gives m = median × (1 − β₁).
+            new_stats.m = median * (1.0 - self._beta1)
+            new_stats.step = 1
+            new_stats.last_latency = median
+            self._stats.append(new_stats)
+            return len(self._workers) - 1
+
+    def remove_worker(self, idx: int) -> "Compute":
+        """Evict a worker from the pool. Returns the evicted Compute."""
+        with self._lock:
+            if not (0 <= idx < len(self._workers)):
+                raise IndexError(f"worker index {idx} out of range")
+            if len(self._workers) == 1:
+                raise ValueError(
+                    "cannot remove the last worker; add a replacement first"
+                )
+            compute = self._workers.pop(idx)
+            self._stats.pop(idx)
+            return compute
+
+    # ................................................................. warmup
+
+    def warmup(
+        self,
+        *,
+        probe_fn: Optional[Any] = None,
+        rounds: int = 3,
+        timeout: float = 10.0,
+        eject_on_failure: bool = True,
+        set_backpressure: bool = True,
+        verbose: bool = True,
+    ) -> dict[str, Any]:
+        """Probe every worker before real traffic to calibrate priors.
+
+        Runs ``rounds`` successful round-trips per worker against a cheap
+        payload (``probe_fn``, defaults to an identity function). The
+        observed latencies seed each worker's EMA, replacing the pessimistic
+        ``initial_latency`` bootstrap.
+
+        When ``eject_on_failure`` is True, workers that fail every probe
+        within ``timeout`` seconds are removed from the pool before the
+        method returns — they never see real traffic.
+
+        When ``set_backpressure`` is True, the method updates
+        ``backpressure_threshold`` to `1.5 × max(observed_worker_latency)`,
+        biasing toward skipping an eval whenever the slow side can't
+        keep up.
+
+        Returns a report dict that callers can log / store:
+
+        .. code-block:: python
+
+            {
+                "rounds": 3,
+                "workers": [
+                    {"idx": 0, "uri": "...", "ok": True,
+                     "latency_mean": 0.31, "latency_p95": 0.42, "observed": [...]},
+                    {"idx": 1, "uri": "...", "ok": False, "reason": "timeout"},
+                ],
+                "ejected": [1],
+                "recommended_backpressure": 0.63,
+                "applied_backpressure": True,
+            }
+
+        """
+        import zakuro as zk
+
+        if probe_fn is None:
+            probe_fn = _identity
+
+        # Wrap probe_fn as a zk.fn we can dispatch to a single worker.
+        probe = zk.fn(probe_fn) if not hasattr(probe_fn, "_func") else probe_fn
+
+        # Snapshot the list of (idx, compute) up-front so mutations during
+        # the walk don't skip or double-count workers.
+        with self._lock:
+            snapshot: list[tuple[int, "Compute"]] = list(enumerate(self._workers))
+
+        worker_reports: list[dict[str, Any]] = []
+        # Track ORIGINAL indices; we translate to current positions right
+        # before eviction (pool may have changed under us).
+        failed_uris: list[str] = []
+
+        for orig_idx, compute in snapshot:
+            observed: list[float] = []
+            err: Optional[str] = None
+            started = time.perf_counter()
+            for _ in range(rounds):
+                remaining = timeout - (time.perf_counter() - started)
+                if remaining <= 0:
+                    err = err or "timeout"
+                    break
+                try:
+                    t0 = time.perf_counter()
+                    probe.to(compute)(_WARMUP_TOKEN)
+                    observed.append(time.perf_counter() - t0)
+                except Exception as exc:
+                    err = repr(exc)
+                    break
+
+            if observed:
+                observed.sort()
+                mean = sum(observed) / len(observed)
+                p95 = observed[min(len(observed) - 1, int(0.95 * len(observed)))]
+                worker_reports.append(
+                    {
+                        "idx": orig_idx,
+                        "uri": getattr(compute, "uri", None),
+                        "ok": True,
+                        "rounds_succeeded": len(observed),
+                        "latency_mean": mean,
+                        "latency_p95": p95,
+                        "observed": list(observed),
+                    }
+                )
+                # Seed the corresponding stats with the mean — look up by
+                # identity since the index may have shifted.
+                with self._lock:
+                    for i, w in enumerate(self._workers):
+                        if w is compute:
+                            s = _WorkerStats()
+                            s.m = mean
+                            s.step = len(observed)
+                            s.last_latency = observed[-1]
+                            self._stats[i] = s
+                            break
+            else:
+                worker_reports.append(
+                    {
+                        "idx": orig_idx,
+                        "uri": getattr(compute, "uri", None),
+                        "ok": False,
+                        "reason": err or "no observations",
+                    }
+                )
+                failed_uris.append(str(getattr(compute, "uri", orig_idx)))
+
+        # Eject failed workers.
+        ejected: list[int] = []
+        if eject_on_failure and failed_uris:
+            with self._lock:
+                keep_workers = []
+                keep_stats = []
+                for i, w in enumerate(self._workers):
+                    uri = str(getattr(w, "uri", i))
+                    if uri in failed_uris and len(self._workers) - len(ejected) > 1:
+                        ejected.append(i)
+                        continue
+                    keep_workers.append(w)
+                    keep_stats.append(self._stats[i])
+                self._workers = keep_workers
+                self._stats = keep_stats
+
+        # Recommend a backpressure threshold from the worst healthy worker's p95.
+        healthy_p95 = [r["latency_p95"] for r in worker_reports if r["ok"]]
+        recommended = max(healthy_p95) * 1.5 if healthy_p95 else None
+        if set_backpressure and recommended is not None:
+            self._backpressure = recommended
+
+        report = {
+            "rounds": rounds,
+            "workers": worker_reports,
+            "ejected": ejected,
+            "recommended_backpressure": recommended,
+            "applied_backpressure": set_backpressure and recommended is not None,
+        }
+
+        if verbose:
+            self._print_warmup_report(report)
+
+        return report
+
+    @staticmethod
+    def _print_warmup_report(report: dict[str, Any]) -> None:
+        parts = []
+        for w in report["workers"]:
+            uri = w.get("uri") or f"worker-{w['idx']}"
+            if w["ok"]:
+                parts.append(f"{uri} (p95={w['latency_p95']:.3f}s)")
+            else:
+                parts.append(f"{uri}: EJECTED ({w['reason']})")
+        summary = ", ".join(parts)
+        bp = report["recommended_backpressure"]
+        bp_str = f"{bp:.2f}s" if bp is not None else "<none>"
+        print(f"[warmup] {summary}")
+        print(f"[warmup] recommended backpressure: {bp_str}")
 
     def dispatch(
         self,
@@ -244,6 +475,23 @@ class AdaptiveCompute:
 
     def _best_expected_time(self) -> float:
         return min(self._expected_times_locked())
+
+    def _mesh_median_latency_locked(self) -> float:
+        """Median of the bias-corrected latency EMAs for observed workers.
+
+        Falls back to ``initial_latency`` if no worker has any observations
+        yet — matches the bootstrap assumption from the first call.
+        """
+        observed = [
+            s.m_hat(self._beta1) for s in self._stats if s.step > 0
+        ]
+        if not observed:
+            return self._initial_latency
+        observed.sort()
+        mid = len(observed) // 2
+        if len(observed) % 2 == 1:
+            return observed[mid]
+        return 0.5 * (observed[mid - 1] + observed[mid])
 
     def _update_ema(self, s: _WorkerStats, latency: float) -> None:
         s.step += 1


### PR DESCRIPTION
## Summary

Implements PLAN phases **1.3 (node lifecycle)** and **2.1 (warmup)** from the roadmap in #94. Every number in this PR is observed on a live 2-worker mesh, not simulated.

## API additions

```python
adaptive = zk.AdaptiveCompute(workers=[...])

# Phase 2.1 — calibrate priors before real traffic
report = adaptive.warmup(rounds=3, timeout=10.0)
#   seeds per-worker EMAs with observed mean latency,
#   ejects workers that fail every probe,
#   sets backpressure_threshold = 1.5 × max(worker_p95).

# Phase 1.3 — mutate the pool at runtime
idx = adaptive.add_worker(zk.Compute(uri="quic://newcomer:4433"))
# Bootstrap prior: m = median × (1 − β₁) so m̂ equals the mesh median
# on step 1 — no stampede onto an unverified worker.
dropped = adaptive.remove_worker(old_idx)
```

Thread-safe (single mutex around all pool mutations + stat reads). `remove_worker` refuses to drop the last worker and raises `ValueError`.

## Observed behaviour on a real 2-worker mesh

Script: `scripts/bench_mesh_adaptation.py --n-workers 2 --dispatch 100`

Two `zakuro-worker --transport http` processes on 127.0.0.1, 100 dispatches per stage.

**Greedy argmin (softmax_temperature = 0):**

| stage | worker 0 picks | worker 1 picks | note |
|---|---|---|---|
| warmup | — | — | p95: 19 ms / 16 ms → `bp = 0.029 s` auto-set |
| post-warmup | 0 (0 %) | 100 (100 %) | Greedy commits to the 3 ms faster one. |
| remove worker 0 | — | 100 | Trivial. |
| readmit worker 0 | 91 (91 %) | 9 (9 %) | Bootstrap prior (17.1 ms) beats the running EMA of worker 1. |

**Softmax (softmax_temperature = 0.01):**

| stage | worker 0 picks | worker 1 picks |
|---|---|---|
| post-warmup | 60 (60 %) | 40 (40 %) |
| readmit worker 0 | 44 (44 %) | 56 (56 %) |

Soft routing keeps both workers utilised and rebalances within a single batch of 100.

## Tests

`tests/test_adaptive.py` gains `TestNodeLifecycle` (3) and `TestWarmup` (3). All pass. Full suite: 126 passed, 3 pre-existing failures unchanged.

## What this unblocks

- SakuraHFCallback can now drop the hand-tuned `backpressure_threshold` argument — the allocator auto-derives it at warmup.
- The roadmap's health-aware dispatch (Phase 1.1) and performance-drift detection (1.2) can build on the lifecycle API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
