### PR TITLE
feat(adaptive): performance-drift detection with soft demotion

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -44,6 +44,16 @@ After warmup the bench sends `tiny.to(adaptive)()` at 10 disp/s, then SIGKILLs w
 
 The probe loop keeps the pool live-updating without draining the foreground dispatch thread — the suspended worker gets no further traffic despite remaining in `adaptive.workers`.
 
+### Drift-injection experiment (`scripts/bench_drift_detection.py`)
+
+Two Mac workers under softmax routing (τ = 0.05). Baseline at t=0, then 10 s of `sleep(0.25)` injected into every request worker 0 serves. Drift detector engages, traffic deflects, and when the injection stops, softmax plus probe-fed EMA bring worker 0 back:
+
+| stage | 0 picks | 1 picks | drift detected |
+|---|---|---|---|
+| baseline 3 s | 26 | 19 | — |
+| injection 10 s | 8 (5 %) | 142 (95 %) | **t + 0.48 s** |
+| recovery 20 s | 167 (56 %) | 133 (44 %) | cleared |
+
 ### Sakura BERT benchmark (x399 4090 trains, Mac MPS evals, distilbert SST-2, 15 epochs)
 
 Repeated from the PR history for context — also measured, also observed:
@@ -98,11 +108,22 @@ The framework floor as of 0.2.3.
 
 Faster tuning trades off against probe traffic volume, but even the "loose" setting beats the PRD's SM2 target of ≤ 10 s by more than an order of magnitude.
 
-### 1.2 Performance drift detection 💭
+### 1.2 Performance drift detection — F3 ✅
 
-- When a worker's latency EMA climbs past its historical p95, mark "suspect" and deprioritise (soft demote).
-- Use the variance EMA (already tracked) as the threshold signal: `m_hat + 3 × sqrt(v_hat)`.
-- Recovery rule: two consecutive dispatches below the historical median → un-demote.
+- Two EMAs per worker: the fast one (`β₁`, current behaviour) and a slower baseline (`β_slow`, long-term behaviour).
+- Detector: when `m_hat / m_slow_hat ≥ drift_threshold` (default 1.5×), the worker's `drift_factor` snaps to `drift_penalty` (default 5×). The factor multiplies the expected time-to-serve in the picker, deflecting traffic without ejecting.
+- Recovery: when `m_hat / m_slow_hat ≤ drift_recovery_threshold` (default 1.1×), `drift_factor` returns to 1.0. Hysteresis prevents flapping.
+- Health probes (Phase 1.1) feed successful-probe latencies back into the EMA, which lets a drifted worker that's since recovered earn its factor back without needing real traffic first.
+
+**Measured on two Mac workers** (`scripts/bench_drift_detection.py`, softmax=0.05, drift_threshold=1.5):
+
+| stage | duration | worker 0 picks | worker 1 picks | observation |
+|---|---|---|---|---|
+| baseline | 3 s | 26 (58 %) | 19 (42 %) | both at ratio ≈ 1.00 |
+| drift injected (worker 0 += 250 ms/call) | 10 s | 8 (5 %) | 142 (95 %) | **drift detected at t+0.48 s**; traffic deflects |
+| recovery (injection off) | 20 s | 167 (56 %) | 133 (44 %) | drift clears via softmax exploration + probe-fed EMA |
+
+Result: from slowdown onset to ≥95 % traffic diversion in under half a second.
 
 ### 1.3 Node admission / departure API — F4.2, F4.3 ✅
 

--- a/scripts/bench_drift_detection.py
+++ b/scripts/bench_drift_detection.py
@@ -1,0 +1,199 @@
+"""Measured drift-injection experiment.
+
+Baseline two workers against a cheap task, then flip one of them into a
+`_slow_task` for a window of time so that every dispatch it serves takes
+~10× longer than normal. Watch:
+
+  * how quickly the drift detector raises ``drift_factor``;
+  * how the pick distribution shifts while drifted;
+  * how the detector releases the worker once latency returns to baseline.
+
+All numbers are measured from the running allocator; nothing is simulated
+after the injection flip.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+import zakuro as zk
+
+
+def _fast_task() -> int:
+    """~0.01 ms of CPU work — used as the baseline dispatch."""
+    x = 0
+    for i in range(10_000):
+        x = (x + i) & 0xFFFFF
+    return x
+
+
+def _slow_task() -> int:
+    """Much slower version — half a second of busy-wait. The experiment
+    toggles between the two to simulate a worker whose throughput has
+    dropped (e.g. it got a noisy neighbour, GPU thermal throttle, network
+    contention). Uses time.sleep so the slowdown dominates over any
+    fixed RPC overhead."""
+    import time as _time
+    _time.sleep(0.25)
+    return 0
+
+
+def _stage(
+    label: str,
+    fn: zk.Fn,
+    adaptive: zk.AdaptiveCompute,
+    slow_fn: zk.Fn,
+    slow_idx: int,
+    duration: float,
+    rate: float,
+) -> dict[str, Any]:
+    """Run dispatches for ``duration`` at ``rate``. For dispatches that
+    the allocator routes to ``slow_idx``, use ``slow_fn`` instead of ``fn``
+    — that's the "injection": as if that worker itself was slower.
+    """
+    interval = 1.0 / max(rate, 0.1)
+    picks = [0 for _ in adaptive.workers]
+    t0 = time.perf_counter()
+    first_drift_t: float | None = None
+    cleared_drift_t: float | None = None
+    injection_active = slow_idx is not None
+    next_at = t0
+    while time.perf_counter() - t0 < duration:
+        now = time.perf_counter()
+        if now >= next_at:
+            idx = adaptive.pick()
+            if injection_active and idx == slow_idx:
+                slow_fn.to(adaptive)()
+            else:
+                fn.to(adaptive)()
+            picks[idx] += 1
+            next_at += interval
+
+        stats = adaptive.stats()
+        if (
+            injection_active
+            and first_drift_t is None
+            and stats[slow_idx]["drift_factor"] > 1.0
+        ):
+            first_drift_t = now - t0
+        if (
+            not injection_active
+            and cleared_drift_t is None
+            and all(s["drift_factor"] == 1.0 for s in stats)
+        ):
+            cleared_drift_t = now - t0
+        time.sleep(0.005)
+
+    return {
+        "label": label,
+        "duration": duration,
+        "picks": picks,
+        "first_drift_secs": first_drift_t,
+        "cleared_drift_secs": cleared_drift_t,
+        "final_stats": adaptive.stats(),
+    }
+
+
+def _print_stage(stage: dict[str, Any]) -> None:
+    print(f"\n--- {stage['label']} ({stage['duration']:.1f}s) ---")
+    for i, n in enumerate(stage["picks"]):
+        s = stage["final_stats"][i]
+        fast = s["latency_ema"] * 1000
+        slow = s["latency_baseline"] * 1000
+        ratio = fast / slow if slow > 0 else float("nan")
+        print(
+            f"  worker {i}: picks={n:>4}  "
+            f"fast_ema={fast:6.1f}ms  baseline={slow:6.1f}ms  "
+            f"ratio={ratio:4.2f}  drift_factor={s['drift_factor']}"
+        )
+    if stage.get("first_drift_secs") is not None:
+        print(f"  drift detected at t+{stage['first_drift_secs']:.2f}s")
+    if stage.get("cleared_drift_secs") is not None:
+        print(f"  drift cleared at t+{stage['cleared_drift_secs']:.2f}s")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--warmup-rounds", type=int, default=4)
+    parser.add_argument("--baseline-secs", type=float, default=5.0)
+    parser.add_argument("--injection-secs", type=float, default=10.0)
+    parser.add_argument("--recovery-secs", type=float, default=10.0)
+    parser.add_argument("--rate", type=float, default=20.0,
+                        help="Dispatches per second.")
+    parser.add_argument("--drift-threshold", type=float, default=1.5)
+    parser.add_argument("--drift-penalty", type=float, default=5.0)
+    parser.add_argument("--beta1", type=float, default=0.7)
+    parser.add_argument("--beta-slow", type=float, default=0.97)
+    parser.add_argument(
+        "--softmax-temperature",
+        type=float,
+        default=0.05,
+        help="Non-zero keeps both workers utilised so drift detection has "
+             "observations to work with. Set to 0 for pure greedy.",
+    )
+    parser.add_argument("--log", default=None)
+    args = parser.parse_args()
+
+    workers = [zk.Worker.spawn(name=f"dr-{i}") for i in range(2)]
+    print(f"spawned: {[w.uri for w in workers]}")
+
+    adaptive = zk.AdaptiveCompute(
+        workers=[w.compute(verify=False) for w in workers],
+        beta1=args.beta1,
+        beta_slow=args.beta_slow,
+        drift_threshold=args.drift_threshold,
+        drift_penalty=args.drift_penalty,
+        softmax_temperature=args.softmax_temperature,
+    )
+    adaptive.warmup(rounds=args.warmup_rounds, verbose=False)
+    # Background heartbeats feed successful probes into the EMA. Without
+    # them, a drifted worker can never recover because traffic stops — no
+    # observations, so the fast EMA stays stuck above the recovery
+    # threshold. With them, the probes let a truly-healthy worker
+    # re-qualify for traffic without a manual reset.
+    adaptive.start_health_probes(interval=0.5, timeout=0.5, max_strikes=6)
+
+    fast = zk.fn(_fast_task)
+    slow = zk.fn(_slow_task)
+
+    report: dict[str, Any] = {
+        "params": vars(args),
+        "stages": [],
+    }
+
+    try:
+        # 1. Baseline — both workers run the fast task.
+        s1 = _stage("baseline", fast, adaptive, slow, slow_idx=None,
+                    duration=args.baseline_secs, rate=args.rate)
+        _print_stage(s1)
+        report["stages"].append(s1)
+
+        # 2. Inject drift into worker 0.
+        s2 = _stage("drift injected (worker 0 slow)",
+                    fast, adaptive, slow, slow_idx=0,
+                    duration=args.injection_secs, rate=args.rate)
+        _print_stage(s2)
+        report["stages"].append(s2)
+
+        # 3. Recover — drop the injection.
+        s3 = _stage("recovery (injection stopped)",
+                    fast, adaptive, slow, slow_idx=None,
+                    duration=args.recovery_secs, rate=args.rate)
+        _print_stage(s3)
+        report["stages"].append(s3)
+    finally:
+        adaptive.stop_health_probes()
+        for w in workers:
+            w.stop()
+
+    if args.log:
+        Path(args.log).write_text(json.dumps(report, indent=2, default=float))
+        print(f"\nlog → {args.log}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_adaptive.py
+++ b/tests/test_adaptive.py
@@ -193,6 +193,80 @@ class TestWarmup:
         assert any(r["ok"] is False for r in report["workers"])
 
 
+class TestDriftDetection:
+    def test_stable_worker_not_drifted(self) -> None:
+        """Consistent latencies keep drift_factor at 1.0."""
+        ac = AdaptiveCompute(
+            workers=[_fast_worker()],
+            beta1=0.8, beta_slow=0.99,
+            drift_threshold=2.0,
+        )
+        for _ in range(50):
+            ac._update_ema(ac._stats[0], 0.1)
+        assert ac.stats()[0]["drift_factor"] == 1.0
+
+    def test_sustained_slowdown_marks_drift(self) -> None:
+        """A worker whose fast EMA climbs past drift_threshold × baseline
+        should be soft-demoted."""
+        ac = AdaptiveCompute(
+            workers=[_fast_worker()],
+            beta1=0.7,          # responsive fast EMA
+            beta_slow=0.95,     # slower baseline
+            drift_threshold=1.5,
+            drift_penalty=5.0,
+        )
+        # Establish baseline.
+        for _ in range(30):
+            ac._update_ema(ac._stats[0], 0.1)
+        assert ac.stats()[0]["drift_factor"] == 1.0
+
+        # Inject 5× slowdown; baseline lags behind so ratio crosses 1.5.
+        for _ in range(15):
+            ac._update_ema(ac._stats[0], 0.5)
+        stats = ac.stats()[0]
+        assert stats["drift_factor"] == 5.0
+        # Expected time in picker = (queue+1) * ema * drift_factor → huge.
+        assert ac._expected_times_locked()[0] > 1.0
+
+    def test_recovery_clears_drift(self) -> None:
+        """Returning to baseline should clear the demotion."""
+        ac = AdaptiveCompute(
+            workers=[_fast_worker()],
+            beta1=0.7, beta_slow=0.95,
+            drift_threshold=1.5,
+            drift_recovery_threshold=1.1,
+        )
+        for _ in range(30):
+            ac._update_ema(ac._stats[0], 0.1)
+        for _ in range(15):
+            ac._update_ema(ac._stats[0], 0.5)
+        assert ac.stats()[0]["drift_factor"] == 5.0
+
+        # Return to fast latencies.
+        for _ in range(60):
+            ac._update_ema(ac._stats[0], 0.1)
+        assert ac.stats()[0]["drift_factor"] == 1.0
+
+    def test_drift_deflects_picks(self) -> None:
+        """In a 2-worker pool, only the drifted side is skipped."""
+        ac = AdaptiveCompute(
+            workers=[_fast_worker(), _slow_worker()],
+            beta1=0.7, beta_slow=0.95,
+            drift_threshold=1.5,
+        )
+        # Baseline both: worker 0 fast, worker 1 fast too.
+        for _ in range(30):
+            ac._update_ema(ac._stats[0], 0.1)
+            ac._update_ema(ac._stats[1], 0.1)
+        # Drift worker 0.
+        for _ in range(15):
+            ac._update_ema(ac._stats[0], 1.0)
+
+        picks = [ac.pick() for _ in range(50)]
+        # All picks should go to the healthy worker 1.
+        assert picks.count(1) == 50
+
+
 class TestHealthProbe:
     def test_probe_miss_marks_strike(self) -> None:
         """A probe that fails (unreachable host) increments health_strikes."""

--- a/zakuro/adaptive.py
+++ b/zakuro/adaptive.py
@@ -99,6 +99,8 @@ class _WorkerStats:
     __slots__ = (
         "m", "v", "step", "queue", "failures", "last_latency",
         "health_strikes", "suspended",
+        # Drift-detection state (Phase 1.2).
+        "m_slow", "drift_factor",
     )
 
     def __init__(self) -> None:
@@ -110,6 +112,10 @@ class _WorkerStats:
         self.last_latency: Optional[float] = None
         self.health_strikes: int = 0
         self.suspended: bool = False
+        # Longer-horizon EMA used as the "baseline" that drift is measured
+        # against. 1.0 = healthy; > 1.0 = deprioritised proportionally.
+        self.m_slow: float = 0.0
+        self.drift_factor: float = 1.0
 
     def m_hat(self, beta1: float) -> float:
         """Bias-corrected first moment. Zero until the first completed call."""
@@ -123,13 +129,21 @@ class _WorkerStats:
             return 0.0
         return self.v / (1.0 - beta2**self.step)
 
-    def to_dict(self, beta1: float, beta2: float) -> dict[str, Any]:
+    def m_slow_hat(self, beta_slow: float) -> float:
+        """Bias-corrected slow-EMA baseline."""
+        if self.step == 0:
+            return 0.0
+        return self.m_slow / (1.0 - beta_slow**self.step)
+
+    def to_dict(self, beta1: float, beta2: float, beta_slow: float) -> dict[str, Any]:
         return {
             "step": self.step,
             "queue": self.queue,
             "failures": self.failures,
             "latency_ema": self.m_hat(beta1),
             "latency_var": self.v_hat(beta2),
+            "latency_baseline": self.m_slow_hat(beta_slow),
+            "drift_factor": self.drift_factor,
             "last_latency": self.last_latency,
             "health_strikes": self.health_strikes,
             "suspended": self.suspended,
@@ -168,6 +182,10 @@ class AdaptiveCompute:
         *,
         beta1: float = 0.9,
         beta2: float = 0.999,
+        beta_slow: float = 0.995,
+        drift_threshold: float = 2.0,
+        drift_penalty: float = 5.0,
+        drift_recovery_threshold: float = 1.1,
         softmax_temperature: float = 0.0,
         initial_latency: float = 1.0,
         backpressure_threshold: float = 30.0,
@@ -177,9 +195,24 @@ class AdaptiveCompute:
             raise ValueError("AdaptiveCompute requires at least one worker.")
         if not (0.0 <= beta1 < 1.0) or not (0.0 <= beta2 < 1.0):
             raise ValueError("beta1, beta2 must be in [0, 1).")
+        if not (0.0 <= beta_slow < 1.0):
+            raise ValueError("beta_slow must be in [0, 1).")
+        if drift_threshold <= 1.0:
+            raise ValueError("drift_threshold must be > 1")
+        if drift_recovery_threshold < 1.0:
+            raise ValueError("drift_recovery_threshold must be ≥ 1")
 
         self._beta1 = beta1
         self._beta2 = beta2
+        # Slower EMA used as "this worker's normal performance". Drift is
+        # detected when the fast EMA rises significantly above this baseline.
+        self._beta_slow = beta_slow
+        # `fast_ema > drift_threshold * baseline` → mark as drifted.
+        self._drift_threshold = float(drift_threshold)
+        # Multiplier applied to the drifted worker's expected time-to-serve.
+        self._drift_penalty = float(drift_penalty)
+        # `fast_ema < drift_recovery_threshold * baseline` → clear the drift.
+        self._drift_recovery = float(drift_recovery_threshold)
         self._tau = float(softmax_temperature)
         self._initial_latency = float(initial_latency)
         self._backpressure = float(backpressure_threshold)
@@ -216,7 +249,10 @@ class AdaptiveCompute:
     def stats(self) -> list[dict[str, Any]]:
         """Snapshot of per-worker stats, bias-corrected."""
         with self._lock:
-            return [s.to_dict(self._beta1, self._beta2) for s in self._stats]
+            return [
+                s.to_dict(self._beta1, self._beta2, self._beta_slow)
+                for s in self._stats
+            ]
 
     def is_backpressured(self) -> bool:
         """True when the best worker's expected time-to-serve exceeds the cap."""
@@ -248,8 +284,10 @@ class AdaptiveCompute:
             new_stats = _WorkerStats()
             # Seed the EMA so the *bias-corrected* m_hat equals the mesh
             # median. m_hat = m / (1 − β₁^step); solving for m with step=1
-            # gives m = median × (1 − β₁).
+            # gives m = median × (1 − β₁). Do the same for the slow EMA so
+            # drift detection has a sensible baseline from the first call.
             new_stats.m = median * (1.0 - self._beta1)
+            new_stats.m_slow = median * (1.0 - self._beta_slow)
             new_stats.step = 1
             new_stats.last_latency = median
             self._stats.append(new_stats)
@@ -369,8 +407,17 @@ class AdaptiveCompute:
                     for i, w in enumerate(self._workers):
                         if w is compute:
                             s = _WorkerStats()
-                            s.m = mean
-                            s.step = len(observed)
+                            step = len(observed)
+                            # Seed the raw EMAs so that bias-corrected `m_hat`
+                            # and `m_slow_hat` BOTH equal the observed mean at
+                            # the current step count. Without this, the longer
+                            # EMA has much stronger bias correction than the
+                            # shorter one and the slow-baseline would read
+                            # artificially large, masking drift or flagging
+                            # spurious drift depending on timing.
+                            s.m = mean * (1.0 - self._beta1**step)
+                            s.m_slow = mean * (1.0 - self._beta_slow**step)
+                            s.step = step
                             s.last_latency = observed[-1]
                             self._stats[i] = s
                             break
@@ -640,7 +687,10 @@ class AdaptiveCompute:
                 continue
             m = s.m_hat(self._beta1)
             lat = m if s.step > 0 else self._initial_latency
-            out.append((s.queue + 1) * lat)
+            # drift_factor softly demotes a drifted worker without ejecting:
+            # it still gets some traffic (so the fast EMA can recover if the
+            # underlying symptom clears) but its expected time is stretched.
+            out.append((s.queue + 1) * lat * s.drift_factor)
         return out
 
     def _best_expected_time(self) -> float:
@@ -671,7 +721,20 @@ class AdaptiveCompute:
         # on-line Welford-style update adopted by Adam-variant implementations.
         deviation = latency - prev_m
         s.v = self._beta2 * s.v + (1.0 - self._beta2) * (deviation * deviation)
+        s.m_slow = self._beta_slow * s.m_slow + (1.0 - self._beta_slow) * latency
         s.last_latency = latency
+        # Drift detection: a worker whose *fast* EMA has climbed past a
+        # multiple of its own *slow* baseline is deprioritised. Only kicks in
+        # after a minimum observation count so we don't trip on a cold start.
+        if s.step >= 8:
+            fast = s.m_hat(self._beta1)
+            baseline = s.m_slow_hat(self._beta_slow)
+            if baseline > 0:
+                ratio = fast / baseline
+                if ratio >= self._drift_threshold:
+                    s.drift_factor = self._drift_penalty
+                elif ratio <= self._drift_recovery and s.drift_factor > 1.0:
+                    s.drift_factor = 1.0
 
     # ........................................................ dunder utilities
 


### PR DESCRIPTION
## Summary

Implements **PLAN phase 1.2** — performance-drift detection. Completes the Phase-1 mesh-awareness block (1.1 + 1.2 + 1.3 + 2.1 all merged).

## Design

Each worker now has two latency EMAs:

- `m` — the fast one, governed by `β₁` (default 0.9). This is the number the picker uses.
- `m_slow` — the slow one, governed by `β_slow` (default 0.995). This is the worker's baseline / "normal" performance.

After every observation (real dispatch or health probe) the allocator checks the ratio `m_hat / m_slow_hat`. If it crosses `drift_threshold` (default 2.0×), `drift_factor` snaps to `drift_penalty` (default 5×). The picker multiplies each worker's expected time-to-serve by its `drift_factor`, so a drifted worker is **soft-demoted** — still eligible for traffic under softmax exploration, still receiving health probes, but deprioritised enough that argmin almost never picks it. When the ratio falls back below `drift_recovery_threshold` (default 1.1×) the factor returns to 1.0. Hysteresis between the two thresholds prevents flapping.

## Companion fixes shipped in this PR

- **warmup() seeding bug.** Previously warmup set `m` from observed mean but left `m_slow = 0`. With a zero baseline the first real dispatch always looked infinitely slow → spurious drift flag. Now both EMAs are seeded from `mean × (1 − βᵢ^step)` so `m_hat` and `m_slow_hat` both equal the observed mean post-warmup.
- **add_worker seeding.** Same issue for new workers; now seeds both EMAs to the mesh median.

## Measured on a real 2-worker mesh

Script: `scripts/bench_drift_detection.py` — two `zakuro-worker` subprocesses on the Mac, HTTP transport, `softmax_temperature=0.05`, `drift_threshold=1.5`, 15 dispatches/second. Baseline stage, then 10 s of `time.sleep(0.25)` injected into every request worker 0 serves, then 20 s of recovery.

| stage | worker 0 picks | worker 1 picks | drift |
|---|---|---|---|
| baseline 3 s | 26 (58 %) | 19 (42 %) | — |
| injection 10 s | 8 (5 %) | 142 (95 %) | **detected at t + 0.48 s** |
| recovery 20 s | 167 (56 %) | 133 (44 %) | cleared via softmax + probe-fed EMA |

From slowdown onset to ≥ 95 % traffic diversion in under half a second. Full rebalance within the 20 s recovery window.

## Tests

4 new unit tests in `test_adaptive.py::TestDriftDetection`:
- `test_stable_worker_not_drifted`
- `test_sustained_slowdown_marks_drift`
- `test_recovery_clears_drift`
- `test_drift_deflects_picks`

26/26 adaptive tests pass. Full suite: same 3 pre-existing unrelated failures.

## PRD traceability

- F3.x (adaptive allocator) extended with variance-based health. ✅
- SM2 (route away from sick worker in ≤ 10 s) — already met via health probes; drift detection adds the "not dead, just slow" case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
