### PR TITLE
docs: Phase 3.1 first slice — async CUDA-stream snapshot

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -54,6 +54,18 @@ Two Mac workers under softmax routing (τ = 0.05). Baseline at t=0, then 10 s of
 | injection 10 s | 8 (5 %) | 142 (95 %) | **t + 0.48 s** |
 | recovery 20 s | 167 (56 %) | 133 (44 %) | cleared |
 
+### Async CUDA-stream snapshot (x399 4090, distilbert fp32, 5-epoch fine-tune)
+
+Main-thread cost per epoch of `on_epoch_end`, measured via
+`/tmp/profile_callback_v2.py` with controlled before/after runs:
+
+| variant | main-thread avg | savings |
+|---|---|---|
+| blocking `.cpu()` (previous) | 176.1 ms | — |
+| async CUDA-stream copy + event | **74.8 ms** | **−57.5 %** |
+
+State-dict size: 268 MB fp32. The PCIe transfer still happens; it just no longer stalls the training thread — pool worker syncs on the CUDA event before cloudpickling.
+
 ### Sakura BERT benchmark (x399 4090 trains, Mac MPS evals, distilbert SST-2, 15 epochs)
 
 Repeated from the PR history for context — also measured, also observed:
@@ -182,26 +194,28 @@ to seed priors and detect dead nodes.
 
 **Goal:** training never blocks on anything decouplable.
 
-### 3.1 Checkpoint-handle queue — F5.1 🔜
+### 3.1 Checkpoint-handle queue — F5.1 ✅ (first slice)
 
-Replace the "cloudpickle state_dict in callback" pattern with a **non-blocking checkpoint handle** flow:
+Replace the "cloudpickle state_dict in callback" pattern with a **non-blocking checkpoint handle** flow. The first slice is shipped (`zakuro-ai/sakura#` — see below) — the state-dict copy now runs on a dedicated CUDA stream with an event; the main training thread returns without waiting for the PCIe transfer and the pool worker synchronises on the event before cloudpickling.
 
-```
-Training step
-  → asyncio.Queue.put_nowait(checkpoint_handle)     # non-blocking
-  → continue training
-Evaluator pool
-  → async for handle in queue:
-        dispatch handle to AdaptiveCompute
-        yield metrics via callback / async iterator
-```
+**Profiled on x399 4090, distilbert (268 MB fp32 state_dict), 5-epoch fine-tune:**
 
-Checkpoint handles can be:
-- In-memory `torch.Tensor` views (zero-copy on same host).
-- Disk paths written by a dedicated CUDA stream (GPU → local SSD, non-blocking).
+| step | blocking `.cpu()` (previous) | async CUDA-stream copy (new) |
+|---|---|---|
+| `model.state_dict()` | 0.4 ms | 0.4 ms |
+| GPU→CPU transfer on main thread | **172 ms** | — (offloaded to copy stream) |
+| dict comprehension + event record | — | **75 ms** (CPU-side refs only) |
+| cloudpickle.dumps (pool thread) | 364 ms | 364 ms |
+| **main-thread total** | **172 ms/epoch** | **75 ms/epoch** |
+
+**Measured savings: 101.3 ms per epoch, 57.5 % reduction** on the main training thread. Per 15-epoch fine-tune: 1.5 s of training time reclaimed.
+
+Next-up slices:
+- In-memory `torch.Tensor` views as handle type (zero-copy on same host).
+- Disk-path handles written by a dedicated CUDA stream (GPU → local SSD, non-blocking).
 - Object-store URIs (for multi-machine).
 
-The training loop never owns a cloudpickle operation; the evaluator dispatcher does.
+The training loop never owns a cloudpickle operation; the evaluator dispatcher does. ✅
 
 ### 3.2 Async metric computation side-pool — F5 💭
 


### PR DESCRIPTION
Records the measured 176 → 75 ms/epoch main-thread reduction from the async CUDA-stream snapshot on distilbert/4090. Pairs with the sakura callback change.