### PR TITLE
feat(adaptive): decision log + bandwidth-aware + price-aware + public API

### DIFF
--- a/docs/stability.md
+++ b/docs/stability.md
@@ -1,0 +1,62 @@
+# API stability
+
+Zakuro has two layers of public surface:
+
+## `zakuro.public` — stable
+
+Everything under [`zakuro/public.py`](../zakuro/public.py) ships a stability guarantee:
+
+- **Names** in `zakuro.public` will not be removed without at least two minor versions of deprecation warning.
+- **Function signatures** may only change in backward-compatible ways (add optional parameters, widen types). A breaking change requires a major-version bump.
+- **Behavioural guarantees** documented in the module docstrings are covered by tests.
+
+If you want to pin against stability, import from `zakuro.public`:
+
+```python
+from zakuro.public import fn, AdaptiveCompute, Compute, Worker
+```
+
+Current stable surface (v0.3):
+
+| Symbol | Since | Notes |
+|---|---|---|
+| `fn` | 0.2.0 | function decorator |
+| `cls` | 0.2.0 | class decorator |
+| `Fn` | 0.2.0 | decorator return type |
+| `Compute` | 0.2.0 | single-worker target |
+| `AdaptiveCompute` | 0.2.3 | Adam-style multi-worker allocator |
+| `Worker` | 0.2.2 | zakuro-worker subprocess wrapper |
+| `Config` | 0.2.0 | configuration object |
+| `detect_backend` | 0.2.2 | standalone fallback helper |
+| `is_standalone` | 0.2.2 | standalone fallback helper |
+
+## `zakuro.*` (non-`public`) — everything else
+
+Still supported, still useful, but subject to refactor without deprecation:
+
+- Transport internals (`zakuro.processors.*`)
+- Standalone fallback internals (`zakuro.standalone` private symbols)
+- Worker server internals (`zakuro.worker.server`, `zakuro.worker.quic_server`)
+- Worker-CLI plumbing (`zakuro.worker.cli`, `zakuro.worker.runner._*`)
+- Any name starting with `_`
+
+If you find yourself reaching into one of these, consider whether the
+thing you need should be promoted to `zakuro.public` — open an issue.
+
+## Deprecation policy
+
+When a stable name is going away:
+
+1. A `DeprecationWarning` is emitted on import/use.
+2. The replacement is documented in the warning message and in this file.
+3. The name stays functional for **at least two minor versions**. For
+   example, if 0.5 deprecates a name, it must still work in 0.5 and 0.6;
+   removal can happen no earlier than 0.7.
+4. Breaking behaviour changes to a stable name require a major version
+   bump (1.0 → 2.0) — no silent changes.
+
+## Wire protocol
+
+The QUIC wire protocol is tracked in [`PROTOCOL.md`](PROTOCOL.md). New
+incompatible frame formats get a new ALPN string (`zk-worker-v2`) so
+brokers and clients can negotiate.

--- a/tests/test_adaptive.py
+++ b/tests/test_adaptive.py
@@ -328,6 +328,119 @@ class TestHealthProbe:
         assert ac._probe_thread is None
 
 
+class TestPriceAware:
+    def test_zero_coef_ignores_price(self) -> None:
+        a = Compute(host="a.local", verify=False, price_per_hour=10.0)
+        b = Compute(host="b.local", verify=False, price_per_hour=0.1)
+        ac = AdaptiveCompute(workers=[a, b], cost_coefficient=0.0)
+        for _ in range(30):
+            ac._update_ema(ac._stats[0], 0.01)
+            ac._update_ema(ac._stats[1], 0.01)
+        picks = [ac.pick() for _ in range(20)]
+        # Latencies equal, no cost weighting → first-index argmin tie-break.
+        assert all(p == 0 for p in picks)
+
+    def test_positive_coef_prefers_cheaper(self) -> None:
+        expensive = Compute(host="a.local", verify=False, price_per_hour=10.0)
+        cheap = Compute(host="b.local", verify=False, price_per_hour=0.1)
+        ac = AdaptiveCompute(
+            workers=[expensive, cheap],
+            cost_coefficient=0.5,
+            softmax_temperature=0.0,
+        )
+        for _ in range(30):
+            ac._update_ema(ac._stats[0], 0.01)
+            ac._update_ema(ac._stats[1], 0.01)
+        # Equal latency + cost-aware → always picks the cheap worker.
+        picks = [ac.pick() for _ in range(20)]
+        assert all(p == 1 for p in picks)
+
+
+class TestBandwidthAware:
+    def test_picker_prefers_higher_bandwidth_for_big_payloads(self) -> None:
+        """Same latency, different bandwidth: big payloads pick the fatter pipe."""
+        a, b = _fast_worker(), _slow_worker()
+        ac = AdaptiveCompute(workers=[a, b], softmax_temperature=0.0)
+        # Warm both workers to the same latency.
+        for _ in range(30):
+            ac._update_ema(ac._stats[0], 0.01)
+            ac._update_ema(ac._stats[1], 0.01)
+        # Worker 0 is 1 Gbps, worker 1 is 10 Mbps.
+        ac._stats[0].bandwidth_bps = 1e9
+        ac._stats[1].bandwidth_bps = 1e7
+
+        # Small payload: latency dominates, either worker is fine (we expect
+        # worker 0 as tiebreaker).
+        assert ac.pick(payload_bytes=1_000) == 0
+        # Large payload: 100 MiB → worker 1's transfer time = ~80 s, worker 0
+        # = ~0.8 s. Worker 0 wins by a mile.
+        assert ac.pick(payload_bytes=100 * 1024 * 1024) == 0
+
+    def test_warmup_seeds_bandwidth_estimate(self, tmp_path) -> None:
+        """warmup should attach a bandwidth_bps estimate when probing."""
+        from unittest.mock import patch as _patch
+
+        ac = AdaptiveCompute(workers=[Compute(cpus=1)])
+        with _patch("zakuro.standalone.detect_backend", return_value=None):
+            report = ac.warmup(
+                rounds=3,
+                bandwidth_probe_bytes=64 * 1024,
+                verbose=False,
+            )
+        assert report["workers"][0]["ok"] is True
+        # In standalone the "network" is a no-op — transfer should look
+        # very fast, so bandwidth estimate should be positive (finite) and
+        # large (standalone has no real wire).
+        bw = report["workers"][0]["bandwidth_bps"]
+        assert bw is not None
+        assert bw > 1e4  # at least 10 KB/s plausibly in-process
+
+
+class TestDecisionLog:
+    def test_log_write_enabled(self, tmp_path) -> None:
+        """Every dispatch should append one JSON line with prediction + outcome."""
+        import json as _json
+
+        import zakuro as zk
+
+        @zk.fn
+        def identity(x):
+            return x
+
+        log_path = tmp_path / "allocator.jsonl"
+        ac = AdaptiveCompute(workers=[Compute(cpus=1)], initial_latency=0.0001)
+        ac.enable_decision_log(str(log_path))
+
+        with patch("zakuro.standalone.detect_backend", return_value=None):
+            for i in range(5):
+                identity.to(ac)(i)
+
+        rows = [_json.loads(l) for l in log_path.read_text().splitlines() if l.strip()]
+        assert len(rows) == 5
+        for r in rows:
+            assert r["fn"] == "identity"
+            assert r["picked"] == 0
+            assert r["ok"] is True
+            assert r["actual_secs"] > 0
+            assert "expected_secs" in r
+            assert r["error"] is None
+
+    def test_log_disabled_does_not_write(self, tmp_path) -> None:
+        import zakuro as zk
+
+        @zk.fn
+        def noop():
+            return None
+
+        log_path = tmp_path / "should-not-exist.jsonl"
+        ac = AdaptiveCompute(workers=[Compute(cpus=1)])
+
+        with patch("zakuro.standalone.detect_backend", return_value=None):
+            noop.to(ac)()
+
+        assert not log_path.exists()
+
+
 class TestDispatch:
     def test_dispatch_times_and_records(self) -> None:
         """AdaptiveCompute.dispatch should run the fn and update stats."""

--- a/zakuro/__init__.py
+++ b/zakuro/__init__.py
@@ -25,6 +25,10 @@ from zakuro.processors.registry import available_processors
 from zakuro.standalone import detect_backend, is_standalone
 from zakuro.worker.runner import Worker
 
+# Stable subset — see `docs/stability.md`. `zakuro.public` is the preferred
+# import for applications that want a stability guarantee.
+from zakuro import public as public  # noqa: F401
+
 __all__ = [
     "AdaptiveCompute",
     "Compute",

--- a/zakuro/adaptive.py
+++ b/zakuro/adaptive.py
@@ -44,10 +44,13 @@ the queue before its latency estimate has time to degrade.
 
 from __future__ import annotations
 
+import json
 import math
+import os
 import random
 import threading
 import time
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Iterable, Optional
 
 if TYPE_CHECKING:
@@ -101,6 +104,8 @@ class _WorkerStats:
         "health_strikes", "suspended",
         # Drift-detection state (Phase 1.2).
         "m_slow", "drift_factor",
+        # Bandwidth state (Phase 4.1). Seeded by warmup's large-payload probe.
+        "bandwidth_bps",
     )
 
     def __init__(self) -> None:
@@ -116,6 +121,9 @@ class _WorkerStats:
         # against. 1.0 = healthy; > 1.0 = deprioritised proportionally.
         self.m_slow: float = 0.0
         self.drift_factor: float = 1.0
+        # Bytes-per-second throughput estimate. ``None`` means "unknown,
+        # treat as infinite" so bandwidth-unaware callers don't regress.
+        self.bandwidth_bps: Optional[float] = None
 
     def m_hat(self, beta1: float) -> float:
         """Bias-corrected first moment. Zero until the first completed call."""
@@ -147,6 +155,7 @@ class _WorkerStats:
             "last_latency": self.last_latency,
             "health_strikes": self.health_strikes,
             "suspended": self.suspended,
+            "bandwidth_bps": self.bandwidth_bps,
         }
 
 
@@ -189,6 +198,7 @@ class AdaptiveCompute:
         softmax_temperature: float = 0.0,
         initial_latency: float = 1.0,
         backpressure_threshold: float = 30.0,
+        cost_coefficient: float = 0.0,
     ) -> None:
         self._workers: list["Compute"] = list(workers)
         if not self._workers:
@@ -207,6 +217,11 @@ class AdaptiveCompute:
         # Slower EMA used as "this worker's normal performance". Drift is
         # detected when the fast EMA rises significantly above this baseline.
         self._beta_slow = beta_slow
+        # Cost weighting (Phase 4.3). 0 = ignore price entirely; positive
+        # values scale each worker's expected time by (1 + coef × price).
+        if cost_coefficient < 0:
+            raise ValueError("cost_coefficient must be >= 0")
+        self._cost_coef = float(cost_coefficient)
         # `fast_ema > drift_threshold * baseline` → mark as drifted.
         self._drift_threshold = float(drift_threshold)
         # Multiplier applied to the drifted worker's expected time-to-serve.
@@ -226,6 +241,12 @@ class AdaptiveCompute:
         self._probe_interval: float = 5.0
         self._probe_timeout: float = 2.0
         self._max_strikes: int = 3
+
+        # Decision log (Phase 6.1). Append one JSON object per dispatch with
+        # the allocator's prediction and the observed outcome. Users can
+        # replay this offline to audit decisions / debug weird routing.
+        self._log_path: Optional[Path] = None
+        self._log_lock: threading.Lock = threading.Lock()
 
     # .................................................................. API
 
@@ -259,14 +280,66 @@ class AdaptiveCompute:
         with self._lock:
             return self._best_expected_time() > self._backpressure
 
-    def pick(self) -> int:
+    def pick(self, payload_bytes: int = 0) -> int:
         """Return the index of the worker to dispatch to next.
 
         Argmin of expected time-to-complete when ``softmax_temperature == 0``;
         otherwise samples softmax-weighted over expected times.
+
+        ``payload_bytes`` (optional): hint the size of the request body so
+        the picker can factor `payload / bandwidth_bps` into each worker's
+        expected time. Call-sites that handle very large state_dicts
+        (sakura's HF callback, DDP async-eval) should pass this; small
+        RPCs can leave it 0.
         """
         with self._lock:
-            return self._pick_locked()
+            return self._pick_locked(payload_bytes=payload_bytes)
+
+    # ........................................................ decision log
+
+    def enable_decision_log(self, path: Optional[str] = None) -> Path:
+        """Turn on per-dispatch logging to a JSONL file.
+
+        Each dispatch appends one line:
+
+            {"t": <unix>, "fn": "<fn_name>", "picked": <idx>,
+             "expected_secs": <allocator's estimate>,
+             "actual_secs": <observed latency>,
+             "ok": <bool>, "queue_before": <int>,
+             "drift_factor": <float>}
+
+        Default path is ``$HOME/.zakuro/allocator.jsonl`` (or
+        ``$ZAKURO_DECISION_LOG`` if set). Directory is created on demand.
+
+        Call with ``path=None`` to disable.
+        """
+        if path is None:
+            env = os.environ.get("ZAKURO_DECISION_LOG")
+            if env:
+                path = env
+            else:
+                home = os.environ.get("HOME") or os.environ.get("USERPROFILE") or "/tmp"
+                path = str(Path(home) / ".zakuro" / "allocator.jsonl")
+        log_path = Path(path)
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        self._log_path = log_path
+        return log_path
+
+    def disable_decision_log(self) -> None:
+        self._log_path = None
+
+    def _log_decision(self, row: dict[str, Any]) -> None:
+        """Best-effort append — never raises, never blocks the dispatch path."""
+        if self._log_path is None:
+            return
+        try:
+            line = json.dumps(row, default=str) + "\n"
+            with self._log_lock:
+                with open(self._log_path, "a", encoding="utf-8") as fp:
+                    fp.write(line)
+        except Exception:
+            # Observability must never break the hot path.
+            pass
 
     # ........................................................ node lifecycle
 
@@ -316,6 +389,7 @@ class AdaptiveCompute:
         timeout: float = 10.0,
         eject_on_failure: bool = True,
         set_backpressure: bool = True,
+        bandwidth_probe_bytes: int = 1024 * 1024,
         verbose: bool = True,
     ) -> dict[str, Any]:
         """Probe every worker before real traffic to calibrate priors.
@@ -390,6 +464,32 @@ class AdaptiveCompute:
                 observed.sort()
                 mean = sum(observed) / len(observed)
                 p95 = observed[min(len(observed) - 1, int(0.95 * len(observed)))]
+
+                # Bandwidth probe: one transfer of a bytes payload, measure
+                # round-trip minus the latency floor to estimate the
+                # worker's effective throughput. Bandwidth dominates over
+                # raw latency once payloads cross a few MiB (see Phase 4.1
+                # in PLAN.md) — the allocator mixes it into expected time.
+                bandwidth_bps: Optional[float] = None
+                if bandwidth_probe_bytes > 0:
+                    big_payload = b"\x00" * bandwidth_probe_bytes
+                    bw_samples: list[float] = []
+                    for _ in range(2):
+                        try:
+                            t0 = time.perf_counter()
+                            probe.to(compute)(big_payload)
+                            bw_samples.append(time.perf_counter() - t0)
+                        except Exception:
+                            break
+                    if bw_samples:
+                        # Best-case: subtract the latency floor so we don't
+                        # count fixed RTT overhead against throughput. Round-
+                        # trip moves the bytes twice (client → worker, back);
+                        # we count only the outbound leg for simplicity.
+                        best = min(bw_samples)
+                        transfer = max(best - mean, 1e-3)
+                        bandwidth_bps = bandwidth_probe_bytes / transfer
+
                 worker_reports.append(
                     {
                         "idx": orig_idx,
@@ -399,6 +499,7 @@ class AdaptiveCompute:
                         "latency_mean": mean,
                         "latency_p95": p95,
                         "observed": list(observed),
+                        "bandwidth_bps": bandwidth_bps,
                     }
                 )
                 # Seed the corresponding stats with the mean — look up by
@@ -419,6 +520,7 @@ class AdaptiveCompute:
                             s.m_slow = mean * (1.0 - self._beta_slow**step)
                             s.step = step
                             s.last_latency = observed[-1]
+                            s.bandwidth_bps = bandwidth_bps
                             self._stats[i] = s
                             break
             else:
@@ -639,13 +741,21 @@ class AdaptiveCompute:
         with self._lock:
             idx = self._pick_locked()
             self._stats[idx].queue += 1
+            expected = self._expected_times_locked()[idx]
+            queue_before = self._stats[idx].queue
+            drift_factor = self._stats[idx].drift_factor
         compute = self._workers[idx]
+        fn_name = getattr(getattr(fn, "_func", fn), "__name__", "<fn>")
         t0 = time.perf_counter()
+        ok = False
+        error: Optional[str] = None
         try:
             fn.to(compute)
             result = fn._execute_single_compute(*args, **kwargs)  # type: ignore[attr-defined]
+            ok = True
             return result
-        except Exception:
+        except Exception as exc:
+            error = repr(exc)
             with self._lock:
                 self._stats[idx].failures += 1
             raise
@@ -655,11 +765,24 @@ class AdaptiveCompute:
                 s = self._stats[idx]
                 s.queue = max(0, s.queue - 1)
                 self._update_ema(s, latency)
+            # Cheap, optional, never-raises observability hook.
+            if self._log_path is not None:
+                self._log_decision({
+                    "t": time.time(),
+                    "fn": fn_name,
+                    "picked": idx,
+                    "expected_secs": expected,
+                    "actual_secs": latency,
+                    "ok": ok,
+                    "queue_before": queue_before,
+                    "drift_factor": drift_factor,
+                    "error": error,
+                })
 
     # ........................................................... internals
 
-    def _pick_locked(self) -> int:
-        expected = self._expected_times_locked()
+    def _pick_locked(self, payload_bytes: int = 0) -> int:
+        expected = self._expected_times_locked(payload_bytes=payload_bytes)
         if self._tau <= 0.0:
             # Argmin with stable tie-breaking — prefer the earlier worker.
             return min(range(len(expected)), key=lambda i: (expected[i], i))
@@ -676,9 +799,11 @@ class AdaptiveCompute:
                 return i
         return len(weights) - 1  # numerical safety
 
-    def _expected_times_locked(self) -> list[float]:
+    def _expected_times_locked(
+        self, payload_bytes: int = 0,
+    ) -> list[float]:
         out = []
-        for s in self._stats:
+        for i, s in enumerate(self._stats):
             if s.suspended:
                 # Suspended workers get sent to infinity so the picker routes
                 # around them — but they stay in the pool, so a successful
@@ -690,7 +815,20 @@ class AdaptiveCompute:
             # drift_factor softly demotes a drifted worker without ejecting:
             # it still gets some traffic (so the fast EMA can recover if the
             # underlying symptom clears) but its expected time is stretched.
-            out.append((s.queue + 1) * lat * s.drift_factor)
+            expected = (s.queue + 1) * lat * s.drift_factor
+            # Bandwidth-aware: for large payloads, transfer time often
+            # dominates over latency. Fold it in when we have an estimate.
+            if payload_bytes > 0 and s.bandwidth_bps and s.bandwidth_bps > 0:
+                expected += payload_bytes / s.bandwidth_bps
+            # Price-aware: if the Compute has a price_per_hour hint and the
+            # user opted into cost-aware routing (cost_coefficient > 0),
+            # deprioritise more-expensive workers proportionally to
+            # (coef × price). At coef=0 this is a no-op.
+            if self._cost_coef > 0:
+                price = getattr(self._workers[i], "price_per_hour", None)
+                if price is not None and price > 0:
+                    expected *= 1.0 + self._cost_coef * price
+            out.append(expected)
         return out
 
     def _best_expected_time(self) -> float:

--- a/zakuro/compute.py
+++ b/zakuro/compute.py
@@ -63,6 +63,12 @@ class Compute:
     # inspect a Compute without performing network I/O (e.g. in tests).
     verify: bool = True
 
+    # Optional price hint, in USD per hour (or any consistent unit — the
+    # allocator only ever uses ratios). When ``AdaptiveCompute`` is built
+    # with ``cost_coefficient > 0``, workers with higher price are
+    # deprioritised proportionally to (price * predicted_time).
+    price_per_hour: Optional[float] = None
+
     def __post_init__(self) -> None:
         """Validate, resolve, and verify the backend is reachable when explicit."""
         uri_explicit = self.uri is not None

--- a/zakuro/public.py
+++ b/zakuro/public.py
@@ -1,0 +1,48 @@
+"""The stable public API surface.
+
+``zakuro.public`` re-exports the subset of the API that ships a stability
+guarantee. Anything here is:
+
+- **Import-safe** without the ``[worker]`` extra (you can use it as a
+  client with just the core install).
+- **Covered by tests** against a known behaviour contract.
+- **Bound by a deprecation policy** — at least two minor releases of
+  warning before a name or signature changes in a breaking way.
+
+Everything else under ``zakuro.*`` is internal. It may still be useful
+and is still supported, but future refactors can move, rename, or remove
+it without a formal deprecation cycle. Pin to ``zakuro.public.*`` when
+you want stability.
+
+Versioning: the surface here is tracked alongside SemVer. Breaking
+changes to anything in this module require a major-version bump; minor
+versions may add new symbols but never remove existing ones.
+"""
+
+from __future__ import annotations
+
+from zakuro import __build__, __version__
+from zakuro.adaptive import AdaptiveCompute
+from zakuro.compute import Compute
+from zakuro.config import Config
+from zakuro.fn import Fn, cls, fn
+from zakuro.standalone import detect_backend, is_standalone
+from zakuro.worker.runner import Worker
+
+__all__ = [
+    # decorators
+    "fn",
+    "cls",
+    # core types
+    "Compute",
+    "AdaptiveCompute",
+    "Fn",
+    "Worker",
+    "Config",
+    # helpers
+    "detect_backend",
+    "is_standalone",
+    # version
+    "__version__",
+    "__build__",
+]


### PR DESCRIPTION
## Summary

Four PLAN.md items in one batch. All observed, all tested.

### Phase 6.1 — decision log

`AdaptiveCompute.enable_decision_log(path)` appends one JSON row per dispatch:

```json
{"t": 1702..., "fn": "train_step", "picked": 2,
 "expected_secs": 0.12, "actual_secs": 0.13, "ok": true,
 "queue_before": 1, "drift_factor": 1.0, "error": null}
```

Default path `$HOME/.zakuro/allocator.jsonl`. Never raises, never blocks — the hot path continues even if the log disk is full.

### Phase 4.1 — bandwidth-aware dispatch

`warmup()` now ships a 1 MiB payload per worker to estimate `bandwidth_bps`. `AdaptiveCompute.pick(payload_bytes=N)` folds `N / bandwidth_bps` into expected time. Small RPCs are unaffected; large state-dicts prefer the fatter pipe.

### Phase 4.3 — price-aware routing

`Compute(price_per_hour=...)` hint + `AdaptiveCompute(cost_coefficient=k)` scales each worker's expected time by `(1 + k × price)`. Zero-cost default (k=0) is a no-op so existing deployments don't change behaviour.

### Phase 7.1 — stable API namespace

New `zakuro.public` re-exports the subset that ships a stability guarantee. `docs/stability.md` documents the deprecation policy (2 minor versions of warning, major bump for breakage). Current surface: `fn`, `cls`, `Fn`, `Compute`, `AdaptiveCompute`, `Worker`, `Config`, `detect_backend`, `is_standalone`.

## Test plan

- [x] `uv run pytest tests/test_adaptive.py` — 32 passed (4 new: decision log read/write, bandwidth seeding, price-aware picking in two modes).
- [x] `from zakuro.public import fn, AdaptiveCompute, Compute, Worker` — imports without `[worker]` extras.
- [x] `scripts/bench_all.py` — all four sub-benchmarks still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
