### PR TITLE
feat(adaptive): topology hints — region/rack-aware routing

### DIFF
--- a/tests/test_adaptive.py
+++ b/tests/test_adaptive.py
@@ -356,6 +356,77 @@ class TestPriceAware:
         assert all(p == 1 for p in picks)
 
 
+class TestTopologyHints:
+    def test_same_region_wins_on_tie(self) -> None:
+        """Equal latency, differing region → picker prefers local region."""
+        local = Compute(host="a.local", verify=False, region="us-west")
+        remote = Compute(host="b.local", verify=False, region="us-east")
+        ac = AdaptiveCompute(
+            workers=[remote, local],  # put the remote at idx 0
+            local_region="us-west",
+            softmax_temperature=0.0,
+        )
+        for _ in range(30):
+            ac._update_ema(ac._stats[0], 0.01)
+            ac._update_ema(ac._stats[1], 0.01)
+        # Despite idx 0 being the first-index tiebreaker, the local worker
+        # (idx 1) wins because the region penalty stretches remote's
+        # expected time.
+        assert all(ac.pick() == 1 for _ in range(20))
+
+    def test_faster_remote_still_wins(self) -> None:
+        """A much-faster remote should beat a slow local — penalty is soft."""
+        slow_local = Compute(host="a.local", verify=False, region="us-west")
+        fast_remote = Compute(host="b.local", verify=False, region="us-east")
+        ac = AdaptiveCompute(
+            workers=[slow_local, fast_remote],
+            local_region="us-west",
+            softmax_temperature=0.0,
+            region_penalty=1.10,
+        )
+        # 10× latency difference dwarfs the 10 % region penalty.
+        for _ in range(30):
+            ac._update_ema(ac._stats[0], 1.0)
+            ac._update_ema(ac._stats[1], 0.01)
+        assert all(ac.pick() == 1 for _ in range(20))
+
+    def test_no_local_region_is_a_noop(self) -> None:
+        """Absent local_region, topology tags on workers are ignored."""
+        a = Compute(host="a.local", verify=False, region="r1")
+        b = Compute(host="b.local", verify=False, region="r2")
+        ac = AdaptiveCompute(workers=[a, b], softmax_temperature=0.0)
+        for _ in range(30):
+            ac._update_ema(ac._stats[0], 0.01)
+            ac._update_ema(ac._stats[1], 0.01)
+        assert all(ac.pick() == 0 for _ in range(20))
+
+    def test_rack_preference_within_region(self) -> None:
+        """Same region, differing rack → prefer same-rack on tie."""
+        cross_rack = Compute(host="a.local", verify=False, region="r", rack="R2")
+        same_rack = Compute(host="b.local", verify=False, region="r", rack="R1")
+        ac = AdaptiveCompute(
+            workers=[cross_rack, same_rack],
+            local_region="r",
+            local_rack="R1",
+            softmax_temperature=0.0,
+        )
+        for _ in range(30):
+            ac._update_ema(ac._stats[0], 0.01)
+            ac._update_ema(ac._stats[1], 0.01)
+        assert all(ac.pick() == 1 for _ in range(20))
+
+    def test_env_var_seeds_local_region(self, monkeypatch) -> None:
+        """$ZAKURO_REGION populates local_region when not passed explicitly."""
+        monkeypatch.setenv("ZAKURO_REGION", "us-west")
+        local = Compute(host="a.local", verify=False, region="us-west")
+        remote = Compute(host="b.local", verify=False, region="us-east")
+        ac = AdaptiveCompute(workers=[remote, local], softmax_temperature=0.0)
+        for _ in range(30):
+            ac._update_ema(ac._stats[0], 0.01)
+            ac._update_ema(ac._stats[1], 0.01)
+        assert all(ac.pick() == 1 for _ in range(20))
+
+
 class TestBandwidthAware:
     def test_picker_prefers_higher_bandwidth_for_big_payloads(self) -> None:
         """Same latency, different bandwidth: big payloads pick the fatter pipe."""

--- a/zakuro/adaptive.py
+++ b/zakuro/adaptive.py
@@ -199,6 +199,10 @@ class AdaptiveCompute:
         initial_latency: float = 1.0,
         backpressure_threshold: float = 30.0,
         cost_coefficient: float = 0.0,
+        local_region: Optional[str] = None,
+        local_rack: Optional[str] = None,
+        region_penalty: float = 1.10,
+        rack_penalty: float = 1.03,
     ) -> None:
         self._workers: list["Compute"] = list(workers)
         if not self._workers:
@@ -222,6 +226,16 @@ class AdaptiveCompute:
         if cost_coefficient < 0:
             raise ValueError("cost_coefficient must be >= 0")
         self._cost_coef = float(cost_coefficient)
+        # Topology preference (Phase 4.2). ``local_region=None`` falls back to
+        # ``$ZAKURO_REGION`` (same for rack) so environments can set this
+        # once per host and every AdaptiveCompute picks it up. Penalties of
+        # 1.0 disable the preference entirely.
+        if region_penalty < 1.0 or rack_penalty < 1.0:
+            raise ValueError("region_penalty and rack_penalty must be >= 1.0")
+        self._local_region = local_region or os.environ.get("ZAKURO_REGION") or None
+        self._local_rack = local_rack or os.environ.get("ZAKURO_RACK") or None
+        self._region_penalty = float(region_penalty)
+        self._rack_penalty = float(rack_penalty)
         # `fast_ema > drift_threshold * baseline` → mark as drifted.
         self._drift_threshold = float(drift_threshold)
         # Multiplier applied to the drifted worker's expected time-to-serve.
@@ -828,6 +842,18 @@ class AdaptiveCompute:
                 price = getattr(self._workers[i], "price_per_hour", None)
                 if price is not None and price > 0:
                     expected *= 1.0 + self._cost_coef * price
+            # Topology-aware: softly demote cross-region (and, secondarily,
+            # cross-rack) workers. Small multipliers so a faster remote
+            # worker still wins on latency — this only breaks near-ties.
+            if self._local_region is not None:
+                w = self._workers[i]
+                w_region = getattr(w, "region", None)
+                if w_region is not None and w_region != self._local_region:
+                    expected *= self._region_penalty
+                elif w_region == self._local_region and self._local_rack is not None:
+                    w_rack = getattr(w, "rack", None)
+                    if w_rack is not None and w_rack != self._local_rack:
+                        expected *= self._rack_penalty
             out.append(expected)
         return out
 

--- a/zakuro/compute.py
+++ b/zakuro/compute.py
@@ -69,6 +69,14 @@ class Compute:
     # deprioritised proportionally to (price * predicted_time).
     price_per_hour: Optional[float] = None
 
+    # Optional topology tags. When the allocator knows its own region/rack
+    # (see ``AdaptiveCompute(local_region=…, local_rack=…)``), it softly
+    # prefers same-region / same-rack workers on otherwise-tied decisions.
+    # Never a hard constraint — a sufficiently faster remote worker still
+    # wins.
+    region: Optional[str] = None
+    rack: Optional[str] = None
+
     def __post_init__(self) -> None:
         """Validate, resolve, and verify the backend is reachable when explicit."""
         uri_explicit = self.uri is not None


### PR DESCRIPTION
## Summary

- `Compute(region="us-west", rack="A1")` — optional network-segment tags.
- `AdaptiveCompute(local_region=..., local_rack=..., region_penalty=1.10, rack_penalty=1.03)` — softly demote cross-region workers on tied decisions.
- `ZAKURO_REGION` / `ZAKURO_RACK` env vars auto-seed the local tags so a host can set them once.

## Why soft, not hard

A same-region worker that's 10× slower shouldn't win. The penalty only breaks near-ties; a faster remote still wins on latency. This matches the principle from PLAN.md §4.2: "allocator prefers same-region when tied on latency".

## Test plan

- [x] 5 new tests in `TestTopologyHints` pass.
- [x] Full `test_adaptive.py` (37 tests) still passes.

Closes Phase 4.2 on PLAN.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
