### PR TITLE
ci: switch PyPI publish to API token (twine)

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -79,8 +79,6 @@ jobs:
     needs: bump-and-release
     runs-on: ubuntu-latest
     environment: release
-    permissions:
-      id-token: write  # OIDC trusted publishing — no token secret required
     steps:
       - uses: actions/checkout@v4
         with:
@@ -95,10 +93,17 @@ jobs:
       - name: Build wheel + sdist
         run: |
           uv venv .venv
-          uv pip install --python .venv/bin/python hatchling build
+          uv pip install --python .venv/bin/python hatchling build twine
           .venv/bin/python -m build --outdir dist
 
-      - name: Publish to PyPI (trusted publishing)
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          packages-dir: dist/
+      - name: Publish to PyPI (API token)
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${TWINE_PASSWORD:-}" ]; then
+            echo "::error::PYPI_API_TOKEN secret is not set on the 'release' environment."
+            exit 1
+          fi
+          .venv/bin/python -m twine upload dist/* --non-interactive


### PR DESCRIPTION
## Summary

Switch PyPI publish to twine + `PYPI_API_TOKEN` secret. Trusted publishing requires a PyPI-side config step that hadn't been done, so the first auto-release failed at the publish step (`invalid-publisher`). Token auth is simpler and doesn't require PyPI config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
