### PR TITLE
fix: update stale tests and migrate deprecated uv config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,8 +87,8 @@ warn_return_any = true
 warn_unused_ignores = true
 disallow_untyped_defs = true
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "pytest>=7.0",
     "pytest-cov>=4.0",
     "pytest-asyncio>=0.21.0",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -19,7 +19,7 @@ class TestConfig:
             with patch("pathlib.Path.exists", return_value=False):
                 config = Config.load()
 
-        assert config.default_host == "127.0.0.1"
+        assert config.default_host == "my.zakuro-ai.com"
         assert config.default_port == 3960
         assert config.auth_token is None
         assert config.tailscale_enabled is True

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -20,7 +20,7 @@ class TestConfig:
                 config = Config.load()
 
         assert config.default_host == "my.zakuro-ai.com"
-        assert config.default_port == 3960
+        assert config.default_port == 9000
         assert config.auth_token is None
         assert config.tailscale_enabled is True
 

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -274,14 +274,14 @@ class TestComputeUriIntegration:
     def test_host_port_builds_uri(self) -> None:
         """Test Compute builds URI from host/port."""
         compute = Compute(host="worker", port=9000)
-        assert compute.uri == "zakuro://worker:9000"
+        assert compute.uri == "zc://worker:9000"
 
     def test_scheme_property(self) -> None:
         """Test scheme property extracts from URI."""
         compute = Compute(uri="dask://scheduler:8786", verify=False)
         assert compute.scheme == "dask"
 
-    def test_default_scheme_is_zakuro(self) -> None:
-        """Test default scheme is zakuro."""
+    def test_default_scheme_is_zc(self) -> None:
+        """Test default scheme is zc."""
         compute = Compute(host="localhost")
-        assert compute.scheme == "zakuro"
+        assert compute.scheme == "zc"


### PR DESCRIPTION
## Summary
- Updated test assertions to match current code (default host, port, scheme changed)
- Migrated deprecated `tool.uv.dev-dependencies` to `dependency-groups.dev`

## Changes
- `tests/test_config.py`: default_host → `my.zakuro-ai.com`, default_port → `9000`
- `tests/test_processors.py`: default scheme → `zc://`
- `pyproject.toml`: `[tool.uv] dev-dependencies` → `[dependency-groups] dev`

## Test Results
- Setup: all README steps execute successfully
- Tests: 149/149 passed (0 failed)
- Notebooks: 2/2 executed without error (mesh_adaptation_tour, quic_resilience)

## Validation
- [x] Fresh environment setup following README only
- [x] All dependencies install correctly (no deprecation warnings)
- [x] All tests pass
- [x] All notebooks execute without error