### PR TITLE
Merge develop: validated setup with passing tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,8 +87,8 @@ warn_return_any = true
 warn_unused_ignores = true
 disallow_untyped_defs = true
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "pytest>=7.0",
     "pytest-cov>=4.0",
     "pytest-asyncio>=0.21.0",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -19,8 +19,8 @@ class TestConfig:
             with patch("pathlib.Path.exists", return_value=False):
                 config = Config.load()
 
-        assert config.default_host == "127.0.0.1"
-        assert config.default_port == 3960
+        assert config.default_host == "my.zakuro-ai.com"
+        assert config.default_port == 9000
         assert config.auth_token is None
         assert config.tailscale_enabled is True
 

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -274,14 +274,14 @@ class TestComputeUriIntegration:
     def test_host_port_builds_uri(self) -> None:
         """Test Compute builds URI from host/port."""
         compute = Compute(host="worker", port=9000)
-        assert compute.uri == "zakuro://worker:9000"
+        assert compute.uri == "zc://worker:9000"
 
     def test_scheme_property(self) -> None:
         """Test scheme property extracts from URI."""
         compute = Compute(uri="dask://scheduler:8786", verify=False)
         assert compute.scheme == "dask"
 
-    def test_default_scheme_is_zakuro(self) -> None:
-        """Test default scheme is zakuro."""
+    def test_default_scheme_is_zc(self) -> None:
+        """Test default scheme is zc."""
         compute = Compute(host="localhost")
-        assert compute.scheme == "zakuro"
+        assert compute.scheme == "zc"


### PR DESCRIPTION
## Summary
- Merges validated fixes from develop
- All tests pass (149/149), all notebooks execute (2/2)
- Tested in clean Ubuntu environment from scratch

## Changes
- Stale test assertions updated to match current code defaults
- Deprecated `tool.uv.dev-dependencies` migrated to `dependency-groups.dev`