### PR TITLE
ci(release): trusted publishing + SLSA provenance + Cosign signing + SBOMs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,55 +3,137 @@ name: Publish
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Tag or commit to publish"
+        required: true
+
+# Hardened release pipeline. Each artifact (the PyPI wheel + the worker and
+# broker container images) is published with:
+#   * Trusted Publishing via OIDC (no long-lived PyPI token)        (#114)
+#   * a CycloneDX SBOM                                              (#120)
+#   * SLSA L3 provenance attached to the GitHub Release             (#120)
+#   * a Cosign keyless signature recorded in Rekor                  (#121)
+#
+# Verification snippet for consumers lives in
+# docs/security/verifying-releases.md, summarised in README.md.
+
+permissions:
+  contents: read
 
 jobs:
-  publish-pypi:
+  # -------------------------------------------------------------------
+  # 1. Build the wheel + its SBOM
+  # -------------------------------------------------------------------
+  build-wheel:
+    name: Build wheel
     runs-on: ubuntu-latest
-    environment: release
+    outputs:
+      hashes: ${{ steps.hash.outputs.hashes }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install build + SBOM tooling
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build cyclonedx-bom
+      - name: Build wheel
+        run: |
+          rm -rf dist/*.whl
+          python -m build --wheel
+      - name: Generate CycloneDX SBOM for the wheel
+        run: |
+          cyclonedx-py environment --output-file dist/sbom.cyclonedx.json --output-format JSON
+      - name: Compute wheel hashes (for SLSA)
+        id: hash
+        working-directory: dist
+        run: |
+          echo "hashes=$(sha256sum *.whl | base64 -w0)" >> "$GITHUB_OUTPUT"
+      - name: Upload wheel + SBOM artefact
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheel
+          path: |
+            dist/*.whl
+            dist/sbom.cyclonedx.json
+          retention-days: 14
+
+  # -------------------------------------------------------------------
+  # 2. SLSA L3 provenance for the wheel
+  # -------------------------------------------------------------------
+  provenance-wheel:
+    name: SLSA provenance (wheel)
+    needs: [build-wheel]
+    permissions:
+      actions: read
+      id-token: write
+      contents: write
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
+    with:
+      base64-subjects: "${{ needs.build-wheel.outputs.hashes }}"
+      upload-assets: true   # attach attestation to the GitHub Release
+
+  # -------------------------------------------------------------------
+  # 3. Publish wheel to PyPI via Trusted Publishing (OIDC, no token)
+  # -------------------------------------------------------------------
+  publish-pypi:
+    name: Publish to PyPI (Trusted Publishing)
+    needs: [build-wheel]
+    runs-on: ubuntu-latest
+    environment:
+      name: release
+      url: https://pypi.org/project/zakuro-ai/
     permissions:
       id-token: write
+      contents: read
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Download wheel
+        uses: actions/download-artifact@v4
         with:
-          python-version: "3.12"
+          name: wheel
+          path: dist
+      - name: Remove non-wheel artefacts before upload
+        run: rm -f dist/sbom.cyclonedx.json
+      - name: Publish via Trusted Publishing
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist
+          # No `password`: OIDC token is fetched from the runner.
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v4
-
-      - name: Install Task
-        uses: arduino/setup-task@v2
-
-      - name: Build wheel
-        run: task build:wheel
-
-      - name: Publish to PyPI
-        run: task deploy:pypi
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-
-  publish-docker:
+  # -------------------------------------------------------------------
+  # 4. Build, push, sign, SBOM each container image
+  # -------------------------------------------------------------------
+  publish-image:
+    name: Publish image
+    needs: [build-wheel]
     runs-on: ubuntu-latest
-    needs: publish-pypi
+    permissions:
+      contents: read
+      id-token: write     # cosign keyless OIDC
+      packages: write     # push to GHCR
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - dockerfile: docker/Dockerfile
+            ghcr_name: ghcr.io/zakuro-ai/zakuro-worker
+            dockerhub_name: zakuroai/zakuro-worker
+            sbom_slug: worker
+          - dockerfile: docker/Dockerfile.broker
+            ghcr_name: ghcr.io/zakuro-ai/zakuro-broker
+            dockerhub_name: zakuroai/zakuro-broker
+            sbom_slug: broker
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Download wheel into build context
+        uses: actions/download-artifact@v4
         with:
-          python-version: "3.12"
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v4
-
-      - name: Install Task
-        uses: arduino/setup-task@v2
-
-      - name: Build wheel
-        run: task build:wheel
+          name: wheel
+          path: dist
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -59,7 +141,74 @@ jobs:
           username: zakuroai
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Build and push Docker image
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve release tag
+        id: tag
         run: |
-          task docker:build
-          task docker:push
+          tag="${{ github.event.release.tag_name }}"
+          if [ -z "$tag" ]; then tag="${{ github.event.inputs.ref }}"; fi
+          # PyPI's wheel filename uses PEP 440; container tags can't have +.
+          tag="${tag#v}"
+          tag="${tag//+/-}"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: true
+          tags: |
+            ${{ matrix.dockerhub_name }}:latest
+            ${{ matrix.dockerhub_name }}:${{ steps.tag.outputs.tag }}
+            ${{ matrix.ghcr_name }}:latest
+            ${{ matrix.ghcr_name }}:${{ steps.tag.outputs.tag }}
+          provenance: mode=max
+          sbom: true
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3.7.0
+
+      - name: Sign image (cosign keyless) and record in Rekor
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          for ref in \
+            "${{ matrix.dockerhub_name }}@${DIGEST}" \
+            "${{ matrix.ghcr_name }}@${DIGEST}"; do
+            cosign sign --yes "$ref"
+          done
+
+      - name: Build CycloneDX SBOM for the image
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: image
+          image-ref: ${{ matrix.ghcr_name }}:${{ steps.tag.outputs.tag }}
+          format: cyclonedx
+          output: sbom-${{ matrix.sbom_slug }}.cyclonedx.json
+          severity: HIGH,CRITICAL
+          exit-code: "0"   # SBOM step, not a scan gate
+
+      - name: Attach SBOM to the image (cosign attest)
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          for ref in \
+            "${{ matrix.dockerhub_name }}@${DIGEST}" \
+            "${{ matrix.ghcr_name }}@${DIGEST}"; do
+            cosign attest --yes --predicate "sbom-${{ matrix.sbom_slug }}.cyclonedx.json" \
+              --type cyclonedx "$ref"
+          done
+
+      - name: Upload SBOM as release asset
+        if: github.event_name == 'release'
+        uses: softprops/action-gh-release@v2
+        with:
+          files: sbom-${{ matrix.sbom_slug }}.cyclonedx.json

--- a/README.md
+++ b/README.md
@@ -222,6 +222,26 @@ task ci:all
 
 Python 3.10+ is required. `uv` is the recommended package manager (`pip install uv`).
 
+## Verifying releases
+
+Every published wheel and container image is signed and attested. Detailed flow in [`docs/security/verifying-releases.md`](docs/security/verifying-releases.md); the one-liners are:
+
+```bash
+# Wheel — SLSA L3 provenance
+slsa-verifier verify-artifact \
+    --provenance-path zakuro_ai-X.Y.Z-py3-none-any.whl.intoto.jsonl \
+    --source-uri github.com/zakuro-ai/zakuro \
+    --source-tag vX.Y.Z \
+    zakuro_ai-X.Y.Z-py3-none-any.whl
+
+# Container image — Cosign keyless (signature lives in Rekor)
+cosign verify ghcr.io/zakuro-ai/zakuro-worker:X.Y.Z \
+    --certificate-identity-regexp '^https://github\.com/zakuro-ai/zakuro/\.github/workflows/publish\.yml@refs/tags/.*$' \
+    --certificate-oidc-issuer https://token.actions.githubusercontent.com
+```
+
+If verification fails on what appears to be a real release, **do not run the artefact** — report to `security@zakuro.ai`.
+
 ## License
 
 BSD-3-Clause. See [`LICENSE`](LICENSE).

--- a/docs/security/verifying-releases.md
+++ b/docs/security/verifying-releases.md
@@ -1,0 +1,75 @@
+# Verifying Zakuro releases
+
+Every Zakuro release is signed and attested:
+
+| Artefact | Signed with | Provenance | SBOM |
+|---|---|---|---|
+| PyPI wheel `zakuro-ai-<version>-py3-none-any.whl` | SLSA L3 (built-in) | SLSA generator | CycloneDX, in `dist/sbom.cyclonedx.json` + GitHub Release asset |
+| Container image `zakuroai/zakuro-worker:<tag>` | Cosign keyless (Sigstore / Rekor) | Cosign SLSA attestation | CycloneDX, attached as `cosign attest` predicate + Release asset |
+| Container image `zakuroai/zakuro-broker:<tag>` | Cosign keyless (Sigstore / Rekor) | Cosign SLSA attestation | CycloneDX, attached as `cosign attest` predicate + Release asset |
+| Same images mirrored to `ghcr.io/zakuro-ai/...` | same | same | same |
+
+All signatures are recorded in the public Rekor transparency log.
+
+The expected signing identity for every release is:
+
+| field | value |
+|---|---|
+| `certificate-identity-regexp` | `^https://github\.com/zakuro-ai/zakuro/\.github/workflows/publish\.yml@refs/tags/.*$` |
+| `certificate-oidc-issuer` | `https://token.actions.githubusercontent.com` |
+
+## Wheel — verify SLSA provenance
+
+```bash
+TAG=v0.2.5                                                      # adjust
+WHEEL=zakuro_ai-${TAG#v}-py3-none-any.whl
+ATT=${WHEEL}.intoto.jsonl
+
+# Download both from the release page:
+gh release download "$TAG" -R zakuro-ai/zakuro -p "$WHEEL" -p "$ATT"
+
+# slsa-verifier checks: signed by the right workflow, builder == GitHub Actions,
+# the wheel SHA matches what the workflow attested.
+slsa-verifier verify-artifact \
+    --provenance-path "$ATT" \
+    --source-uri github.com/zakuro-ai/zakuro \
+    --source-tag "$TAG" \
+    "$WHEEL"
+```
+
+If the wheel was tampered with, the digest comparison fails. If the attestation was forged, the Sigstore cert chain fails.
+
+## Container image — verify Cosign signature
+
+```bash
+IMAGE=ghcr.io/zakuro-ai/zakuro-worker:0.2.5   # or zakuroai/zakuro-worker:0.2.5
+
+cosign verify "$IMAGE" \
+    --certificate-identity-regexp '^https://github\.com/zakuro-ai/zakuro/\.github/workflows/publish\.yml@refs/tags/.*$' \
+    --certificate-oidc-issuer https://token.actions.githubusercontent.com
+```
+
+Unsigned or tampered images fail verification. There is no fall-through path.
+
+## Container image — retrieve the SBOM
+
+```bash
+# CycloneDX SBOM attached as a Cosign attestation
+cosign download attestation "$IMAGE" --predicate-type=cyclonedx \
+    | jq -r .payload | base64 -d | jq .
+```
+
+## Pin to a digest for production
+
+After verifying once, prefer immutable pinning:
+
+```bash
+DIGEST=$(docker buildx imagetools inspect "$IMAGE" --format '{{.Manifest.Digest}}')
+echo "$IMAGE@$DIGEST"
+```
+
+Use `$IMAGE@$DIGEST` in `docker-compose.yml`, Helm values, Kubernetes manifests, etc. — the tag can be reassigned, the digest cannot.
+
+## Reporting a verification failure
+
+If `cosign verify` or `slsa-verifier verify-artifact` fails on a wheel or image we appear to have released, **do not run the artefact**. Report to **security@zakuro.ai** (see [`SECURITY.md`](../../SECURITY.md)) — a verification failure on a legitimate Zakuro release is either a supply-chain incident or a packaging bug, and we treat both at the same priority.


### PR DESCRIPTION
## Summary

Hardens the release pipeline to close three supply-chain tickets in one PR (surface-only, no runtime code). Each release artefact now ships with a verifiable identity:

| Artefact | Signed with | Provenance | SBOM |
|---|---|---|---|
| PyPI wheel | SLSA L3 (slsa-github-generator) | attached to GitHub Release | CycloneDX in \`dist/\` + Release asset |
| \`zakuroai/zakuro-worker:<tag>\` | Cosign keyless → Rekor | Cosign attestation | CycloneDX via \`cosign attest\` + Release asset |
| \`zakuroai/zakuro-broker:<tag>\` | Cosign keyless → Rekor | Cosign attestation | CycloneDX via \`cosign attest\` + Release asset |
| Same images mirrored to \`ghcr.io/zakuro-ai/...\` | same | same | same |

## Issues closed

| Issue | What changes |
|---|---|
| **#114 Trusted Publishing** | Drop \`twine\` + \`PYPI_API_TOKEN\`; publish via \`pypa/gh-action-pypi-publish@release/v1\` under \`environment: release\` using the OIDC token. |
| **#120 SBOM + SLSA provenance** | Wheel SBOM via \`cyclonedx-py\`; image SBOM via \`trivy sbom\`; SLSA L3 provenance via \`slsa-framework/slsa-github-generator\` reusable workflow; SBOMs attached to the GitHub Release and to each image as \`cosign attest --type cyclonedx\`. |
| **#121 Cosign keyless image signing** | Every image (worker + broker, Docker Hub + GHCR) signed with \`cosign sign --yes\` using the GitHub OIDC identity; signatures land in the public Rekor transparency log automatically. README gets a verify snippet; \`docs/security/verifying-releases.md\` documents the full flow. |

## Manual follow-up after merge

These are admin actions outside the diff:

- **#114**: register the trusted publisher on pypi.org for project \`zakuro-ai\`, environment \`release\`, workflow \`publish.yml\`. Revoke the existing \`PYPI_API_TOKEN\` secret. Configure required reviewers on the \`release\` environment.
- **#121 Helm chart deliverable**: deferred — there is no Helm chart in this repo yet. The Helm chart admission-policy + pre-install hook should be folded into **#132** (the Helm chart ticket).

## Test plan

- [ ] CI lints / typechecks unaffected (this PR only touches \`.github/workflows/publish.yml\`, \`README.md\`, and adds \`docs/security/verifying-releases.md\`).
- [ ] Workflow YAML is syntactically valid (validated locally).
- [ ] Cut a 0.2.5 pre-release on this branch (via \`workflow_dispatch\` with \`ref: sprint/supply-chain\`) and verify:
  - [ ] PyPI page shows "Uploaded using Trusted Publishing? Yes".
  - [ ] GitHub Release has wheel SBOM + image SBOMs + SLSA \`.intoto.jsonl\` attestation.
  - [ ] \`slsa-verifier verify-artifact\` passes on the wheel.
  - [ ] \`cosign verify\` passes on each image with the expected identity regex.
  - [ ] \`cosign download attestation --predicate-type=cyclonedx\` returns the CycloneDX SBOM.

Closes #114
Closes #120
Closes #121