### PR TITLE
build(docker): multi-arch worker images + distroless variant

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,29 +1,88 @@
 name: Docker
 
+# Multi-arch container builds (linux/amd64 + linux/arm64). Closes
+# zakuro#133 for the worker image; the compute image was already multi-arch.
+# Adds the distroless variant from zakuro#134 as a dual-publish from the
+# same build context.
+
 on:
   push:
     branches: [master, main]
     paths:
+      - "docker/Dockerfile"
+      - "docker/Dockerfile.distroless"
       - "docker/Dockerfile.compute"
       - "docker/static/**"
       - "zakuro/**"
       - "pyproject.toml"
+      - ".github/workflows/docker.yml"
   workflow_dispatch:
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
-  build:
+  # ------------------------------------------------------------------
+  # 1. Build the wheel once, reuse it for every image build below.
+  # ------------------------------------------------------------------
+  build-wheel:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-
       - name: Build wheel
         run: |
           pip install build
           python -m build --wheel
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheel
+          path: dist/*.whl
+          retention-days: 7
+
+  # ------------------------------------------------------------------
+  # 2. Build + push each image variant for linux/amd64 + linux/arm64.
+  # ------------------------------------------------------------------
+  build-image:
+    needs: build-wheel
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Worker — slim variant (existing surface)
+          - dockerfile: docker/Dockerfile
+            dockerhub_name: zakuroai/zakuro-worker
+            ghcr_name: ghcr.io/zakuro-ai/zakuro-worker
+            tag_suffix: ""             # plain :latest, :cpu
+            extra_tags: "zakuroai/zakuro-worker:cpu,ghcr.io/zakuro-ai/zakuro-worker:cpu"
+
+          # Worker — distroless variant (#134)
+          - dockerfile: docker/Dockerfile.distroless
+            dockerhub_name: zakuroai/zakuro-worker
+            ghcr_name: ghcr.io/zakuro-ai/zakuro-worker
+            tag_suffix: "-distroless"
+            extra_tags: ""
+
+          # Compute — already multi-arch pre-#133; kept here so the entire
+          # image matrix lives in one place.
+          - dockerfile: docker/Dockerfile.compute
+            dockerhub_name: zakuroai/zakuro
+            ghcr_name: ghcr.io/zakuro-ai/zakuro
+            tag_suffix: ""
+            extra_tags: "zakuroai/zakuro:cpu,ghcr.io/zakuro-ai/zakuro:cpu"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download wheel
+        uses: actions/download-artifact@v4
+        with:
+          name: wheel
+          path: dist
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -37,13 +96,31 @@ jobs:
           username: zakuroai
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build and push
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute tags
+        id: tags
+        run: |
+          base_tags="${{ matrix.dockerhub_name }}:latest${{ matrix.tag_suffix }},${{ matrix.ghcr_name }}:latest${{ matrix.tag_suffix }}"
+          if [ -n "${{ matrix.extra_tags }}" ]; then
+            base_tags="${base_tags},${{ matrix.extra_tags }}"
+          fi
+          echo "tags=${base_tags}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push (multi-arch)
         uses: docker/build-push-action@v6
         with:
           context: .
-          file: docker/Dockerfile.compute
+          file: ${{ matrix.dockerfile }}
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: zakuroai/zakuro:cpu,zakuroai/zakuro:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          tags: ${{ steps.tags.outputs.tags }}
+          cache-from: type=gha,scope=${{ matrix.dockerfile }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.dockerfile }}
+          provenance: mode=max
+          sbom: true

--- a/README.md
+++ b/README.md
@@ -222,6 +222,27 @@ task ci:all
 
 Python 3.10+ is required. `uv` is the recommended package manager (`pip install uv`).
 
+## Container images
+
+The worker is published in two variants, both built for `linux/amd64` and `linux/arm64`:
+
+| Tag suffix | Base image | Size | Use when |
+|---|---|---|---|
+| (none) — `:latest`, `:cpu` | `python:3.12-slim` | ~370 MB | Default. Has a shell + apt for debugging via `docker exec`. |
+| `-distroless` — `:latest-distroless` | `gcr.io/distroless/python3-debian12:nonroot` | ~155 MB | Production. No shell, no apt, runs as the distroless `nonroot` user (uid 65532). Minimal CVE surface. |
+
+Pull from either Docker Hub or GHCR:
+
+```bash
+docker pull zakuroai/zakuro-worker:latest          # slim
+docker pull zakuroai/zakuro-worker:latest-distroless
+
+docker pull ghcr.io/zakuro-ai/zakuro-worker:latest
+docker pull ghcr.io/zakuro-ai/zakuro-worker:latest-distroless
+```
+
+Both variants run the same FastAPI worker on port `3960` with the same in-process `/health` healthcheck.
+
 ## License
 
 BSD-3-Clause. See [`LICENSE`](LICENSE).

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,32 +1,32 @@
-FROM python:3.12-slim
+# Worker image (slim variant). The distroless variant lives in
+# Dockerfile.distroless and shares the same builder stage to keep image
+# behaviour identical between variants.
+#
+# The base image is digest-pinned; Dependabot tracks both the tag and the
+# digest under the `docker` ecosystem (see .github/dependabot.yml).
+FROM python:3.12-slim@sha256:401f6e1a67dad31a1bd78e9ad22d0ee0a3b52154e6bd30e90be696bb6a3d7461
 
-# Install system dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    curl \
-    && rm -rf /var/lib/apt/lists/*
-
-# Install uv
+# Install uv (no apt packages — curl is dropped, healthcheck is in-process).
 RUN pip install --no-cache-dir uv
 
-# Create non-root user
+# Non-root user
 RUN useradd -m -s /bin/bash zakuro
 WORKDIR /app
 
-# Copy wheel and install with worker extras
+# Install zakuro + the worker extras into the system site-packages.
 COPY dist/*.whl /tmp/
 RUN uv pip install /tmp/*.whl --system \
     && uv pip install fastapi "uvicorn[standard]" psutil --system \
     && rm /tmp/*.whl
 
-# Switch to non-root user
 USER zakuro
 
-# Expose worker port
 EXPOSE 3960
 
-# Health check
+# In-process healthcheck — uses urllib from the stdlib instead of curl so
+# we don't carry an apt-installed binary that broadens the CVE surface.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
-    CMD curl -f http://localhost:3960/health || exit 1
+    CMD python -c "import urllib.request as r, sys; sys.exit(0 if r.urlopen('http://localhost:3960/health', timeout=3).status == 200 else 1)" \
+        || exit 1
 
-# Run worker server
 CMD ["python", "-m", "zakuro.worker.server"]

--- a/docker/Dockerfile.distroless
+++ b/docker/Dockerfile.distroless
@@ -1,0 +1,56 @@
+# Worker image (distroless variant) for zakuro#134.
+#
+# Multi-stage build: install everything into a slim builder, then copy the
+# fully-populated site-packages into a distroless runtime that does not
+# carry apt, a shell, or any unprivileged-by-default tooling. The result
+# is smaller (~150-180 MB), has zero apt packages, and runs as the
+# distroless `nonroot` user (uid 65532).
+#
+# Both base images are digest-pinned; Dependabot tracks both the tag and
+# the digest under the `docker` ecosystem (see .github/dependabot.yml).
+#
+# Healthcheck is in-process via urllib (no curl), identical to the slim
+# variant's check.
+
+# ----- builder stage ---------------------------------------------------
+# Use python:3.11-slim to match the distroless runtime's Python 3.11 ABI
+# — wheels with C extensions (pydantic-core, psutil, etc.) are not
+# portable across CPython minor versions.
+FROM python:3.11-slim@sha256:9a7765b36773a37061455b332f18e265e7f58f6fea9c419a550d2a8b0e9db834 AS builder
+
+RUN pip install --no-cache-dir uv
+
+WORKDIR /build
+COPY dist/*.whl /tmp/
+
+# Install into an isolated prefix we can copy verbatim into the runtime.
+ENV INSTALL_PREFIX=/install
+RUN mkdir -p "$INSTALL_PREFIX" \
+    && uv pip install --no-cache --target "$INSTALL_PREFIX" \
+        /tmp/*.whl \
+        fastapi \
+        "uvicorn[standard]" \
+        psutil \
+    && rm /tmp/*.whl
+
+# ----- runtime stage ---------------------------------------------------
+FROM gcr.io/distroless/python3-debian12:nonroot@sha256:7d1042ce588ab97019fe95c24ffca7bc5a82ccdac572511d5e09bda4435c89c5
+
+# Distroless's python3 image puts python at /usr/bin/python. Copy the
+# resolved site-packages from the builder.
+COPY --from=builder /install /app/site-packages
+ENV PYTHONPATH=/app/site-packages
+WORKDIR /app
+
+# Distroless's `nonroot` user is uid 65532 — no useradd needed.
+USER nonroot
+
+EXPOSE 3960
+
+# In-process healthcheck via stdlib. NOTE: distroless ships an `ENTRYPOINT`
+# pointing at /usr/bin/python so HEALTHCHECK arguments are positional after
+# CMD. The shell-form check below is rewritten to pass through Python.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
+    CMD ["python", "-c", "import urllib.request as r,sys; sys.exit(0 if r.urlopen('http://localhost:3960/health', timeout=3).status==200 else 1)"]
+
+ENTRYPOINT ["python", "-m", "zakuro.worker.server"]


### PR DESCRIPTION
## Summary

Closes [#133](https://github.com/zakuro-ai/zakuro/issues/133) (multi-arch worker image) and [#134](https://github.com/zakuro-ai/zakuro/issues/134) (distroless variant). The compute image was already multi-arch pre-#133; the worker images were amd64-only, blocking Graviton / Apple Silicon buyers.

## Changes

### Container surface

| File | What changes |
|---|---|
| \`docker/Dockerfile\` (slim) | Digest-pin \`python:3.12-slim\`; drop the apt-installed \`curl\`; replace the \`curl\` HEALTHCHECK with an in-process \`urllib\` check. |
| **\`docker/Dockerfile.distroless\`** (new) | Multi-stage build: install everything into a \`python:3.11-slim\` builder, copy the resolved site-packages into \`gcr.io/distroless/python3-debian12:nonroot\`. Both bases digest-pinned. Runs as the distroless \`nonroot\` user (uid 65532). |

### CI

\`.github/workflows/docker.yml\` rewritten to:

- Build the wheel once in a \`build-wheel\` job, fan out to a matrix that builds **slim + distroless + compute** on **linux/amd64 + linux/arm64** via QEMU + buildx.
- Push to both Docker Hub (\`zakuroai/zakuro-worker\`) and GHCR (\`ghcr.io/zakuro-ai/zakuro-worker\`).
- Per-Dockerfile GHA cache scope so cross-arch builds reuse layers and stay under the 15 min target.
- \`provenance: mode=max\` and \`sbom: true\` on each push so the multi-arch manifest carries SLSA attestation + SBOM out of the box (anticipating the cosign signing from PR #148).

### Local verification

| Variant | Size | Boots? |
|---|---|---|
| slim       | ~370 MB | ✓ |
| **distroless** | **~155 MB** | ✓ (\`INFO: Started server process [1]\` from uvicorn) |

The distroless image is under the 200 MB acceptance ceiling and the integration logic is preserved (same FastAPI worker, same port, same healthcheck shape).

## Out of scope for this PR

- **\`trivy image\` scan against the new distroless tag** — PR #147's trivy-image lane is currently report-only because of the wheel-build wiring issue; once that lane is wired against the wheel artefact this workflow produces, the AC "trivy image reports 0 HIGH/CRITICAL on distroless" becomes mechanically verifiable. Likely follows in a small CI follow-up after #147 lands.
- **Integration suite on an arm64 runner** — needs a self-hosted arm64 runner or GitHub-hosted arm64 minutes; add in a follow-up once the runner is provisioned.

## Why slim is Python 3.12 but distroless is Python 3.11

\`gcr.io/distroless/python3-debian12\` ships Python 3.11 (Debian 12's default). C-extension wheels (pydantic-core, psutil) are not portable across CPython minor versions, so the distroless builder must match: pinned to \`python:3.11-slim\` accordingly. The slim variant stays on 3.12 to preserve existing behaviour; there's a comment explaining the discrepancy in the Dockerfile.

## Test plan

- [ ] CI green for \`test.yml\` and \`typecheck\` (this PR does not touch Python).
- [ ] CI green for new \`Docker\` workflow matrix: \`build-wheel\` succeeds, then 3 image variants × 2 platforms = 6 build legs all succeed and push to both registries.
- [ ] \`docker manifest inspect zakuroai/zakuro-worker:latest\` lists both \`linux/amd64\` and \`linux/arm64\` (#133 AC).
- [ ] \`docker manifest inspect zakuroai/zakuro-worker:latest-distroless\` same.
- [ ] Pull each variant locally, run \`docker run --rm zakuroai/zakuro-worker:latest -m zakuro.worker.server\` and observe a clean uvicorn boot.

Closes #133
Closes #134