### PR TITLE
feat(secrets): adopt SOPS + age for in-tree secret encryption (#118)

### DIFF
--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -96,3 +96,37 @@ jobs:
         with:
           sarif_file: gitleaks.sarif
           category: gitleaks
+
+  sops-encryption-check:
+    name: SOPS encryption check
+    # Closes the CI half of #118: refuse to merge if a file matching the
+    # secret naming convention is committed in plaintext. Strict by design
+    # (no continue-on-error) — a leaked secret is the one thing we do not
+    # want to ratchet.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Find files that look like secrets but are not encrypted
+        run: |
+          set -eu
+
+          # Files we expect to be SOPS-encrypted.
+          mapfile -t candidates < <(
+            git ls-files \
+              'secrets/*' \
+              '*.sops.yaml' \
+              '*.sops.json' \
+              '*.sops.env' \
+              | grep -v -E '^(secrets/README\.md|\.sops\.yaml)$' || true
+          )
+
+          fail=0
+          for f in "${candidates[@]}"; do
+            [ -n "$f" ] || continue
+            if ! grep -q '"sops":' "$f" 2>/dev/null \
+               && ! grep -q '^sops:' "$f" 2>/dev/null; then
+              echo "::error file=$f::file matches the secret naming convention but does not appear to be SOPS-encrypted"
+              fail=1
+            fi
+          done
+          exit "$fail"

--- a/.sops.yaml
+++ b/.sops.yaml
@@ -1,0 +1,29 @@
+# SOPS configuration for zakuro-ai/zakuro (#118).
+#
+# Encrypts in-tree secret files at rest with age public keys. Decryption
+# happens locally (devs with the corresponding age private keys) and in
+# CI/CD (via a runner-scoped age private key in repo secrets).
+#
+# See docs/secrets.md for the full developer workflow.
+#
+# Naming convention:
+#   *.sops.yaml    -> encrypted YAML
+#   *.sops.json    -> encrypted JSON
+#   *.sops.env     -> encrypted dotenv
+#   secrets/**     -> directory of encrypted files
+#
+# To rotate the recipient list, update `creation_rules.age` below and run
+# `sops updatekeys path/to/file.sops.yaml` for every file under that rule.
+
+creation_rules:
+  # Default rule: anything under `secrets/` or matching `*.sops.*` gets
+  # encrypted with the current team age keys.
+  - path_regex: '(^|/)secrets/.*$|.*\.sops\.(yaml|json|env)$'
+    encrypted_regex: '^(data|password|token|secret|key|dsn|credentials|.*_KEY|.*_TOKEN|.*_PASSWORD|.*_SECRET|.*_DSN)$'
+    age: >-
+      # team-key-2026 (placeholder until first key is generated):
+      # age1placeholder000000000000000000000000000000000000000000000
+      #
+      # Add real age public keys here, one per recipient, separated by
+      # commas. Generate with `age-keygen -o ~/.config/sops/age/keys.txt`.
+      age1placeholder000000000000000000000000000000000000000000000

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -22,7 +22,7 @@ Zakuro encrypts in-tree secrets at rest with [SOPS](https://github.com/getsops/s
    # The public key (starts with `age1...`) is printed on stderr.
    ```
 
-3. **Get added to the recipient list.** Share your `age1...` public key with a maintainer; they will append it to [`.sops.yaml`](../.sops.yaml) under `creation_rules.age` and run `sops updatekeys` on every existing encrypted file so you can decrypt them too.
+3. **Get added to the recipient list.** Share your `age1...` public key with a maintainer; they will append it to [`.sops.yaml`](https://github.com/zakuro-ai/zakuro/blob/master/.sops.yaml) under `creation_rules.age` and run `sops updatekeys` on every existing encrypted file so you can decrypt them too.
 
 4. **Edit / read a secret.**
 
@@ -60,7 +60,7 @@ A minimal init wrapper lives at `scripts/sops-decrypt-runtime.sh` and is invoked
 ## Verification flow
 
 - **Local:** `sops --decrypt secrets/<file>.sops.yaml | jq '.'` returns plaintext if your age key is in the recipient list, fails cleanly otherwise.
-- **CI:** the `secrets-pre-commit-check` workflow refuses to merge a PR that contains a file matching the secret naming convention but is *not* actually encrypted (see [`.github/workflows/sast.yml`](../.github/workflows/sast.yml) — `secrets-encryption-check` job).
+- **CI:** the `secrets-pre-commit-check` workflow refuses to merge a PR that contains a file matching the secret naming convention but is *not* actually encrypted (see [`.github/workflows/sast.yml`](https://github.com/zakuro-ai/zakuro/blob/master/.github/workflows/sast.yml) — `sops-encryption-check` job).
 - **Releases:** the supply-chain pipeline (PR #148) does not embed any secret in shipped artifacts; secrets are only injected at boot.
 
 ## Rotation

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -1,0 +1,89 @@
+# Secrets management
+
+Closes #118.
+
+Zakuro encrypts in-tree secrets at rest with [SOPS](https://github.com/getsops/sops) + [age](https://github.com/FiloSottile/age). This keeps secrets versioned with the code, auditable through git history, and decryptable both locally (by developers with the team key) and in CI/CD (by a runner-scoped key in repo secrets).
+
+## Quick start (developer)
+
+1. **Install tooling.** macOS:
+
+   ```bash
+   brew install sops age
+   ```
+
+   Linux: download binaries from the [SOPS releases](https://github.com/getsops/sops/releases) and [age releases](https://github.com/FiloSottile/age/releases) pages.
+
+2. **Generate your age key pair once.**
+
+   ```bash
+   mkdir -p ~/.config/sops/age
+   age-keygen -o ~/.config/sops/age/keys.txt
+   # The public key (starts with `age1...`) is printed on stderr.
+   ```
+
+3. **Get added to the recipient list.** Share your `age1...` public key with a maintainer; they will append it to [`.sops.yaml`](../.sops.yaml) under `creation_rules.age` and run `sops updatekeys` on every existing encrypted file so you can decrypt them too.
+
+4. **Edit / read a secret.**
+
+   ```bash
+   sops secrets/sentry-dsn.sops.yaml   # opens decrypted in $EDITOR
+   sops -d secrets/sentry-dsn.sops.yaml > /tmp/dsn.yaml   # decrypt to file
+   ```
+
+5. **Create a new secret.** Drop a plaintext YAML at the target path, then encrypt in place:
+
+   ```bash
+   sops --encrypt --in-place secrets/foo.sops.yaml
+   ```
+
+   The `.sops.yaml` config picks the right age recipients automatically based on the path.
+
+## File naming convention
+
+The `.sops.yaml` `creation_rules` rule matches:
+
+- Any file under `secrets/`
+- Any file matching `*.sops.yaml`, `*.sops.json`, `*.sops.env`
+
+Within each file, only keys named `data`, `password`, `token`, `secret`, `key`, `dsn`, `credentials`, or any name ending in `_KEY`, `_TOKEN`, `_PASSWORD`, `_SECRET`, `_DSN` are encrypted. Everything else (structural metadata, comments, schema version) stays in plaintext so the file is still readable in code review.
+
+## CI / production loading
+
+For workers + the broker in production:
+
+1. The runner / pod is given a single age private key via the platform's secret-store (k8s Secret, GH Actions `secrets.SOPS_AGE_KEY`, GCP Secret Manager — see [Verification flow](#verification-flow)).
+2. At boot, an init script decrypts the configured secret files into a memory-backed location (tmpfs) and exports them as env vars.
+
+A minimal init wrapper lives at `scripts/sops-decrypt-runtime.sh` and is invoked by the entrypoint of the worker / broker images.
+
+## Verification flow
+
+- **Local:** `sops --decrypt secrets/<file>.sops.yaml | jq '.'` returns plaintext if your age key is in the recipient list, fails cleanly otherwise.
+- **CI:** the `secrets-pre-commit-check` workflow refuses to merge a PR that contains a file matching the secret naming convention but is *not* actually encrypted (see [`.github/workflows/sast.yml`](../.github/workflows/sast.yml) — `secrets-encryption-check` job).
+- **Releases:** the supply-chain pipeline (PR #148) does not embed any secret in shipped artifacts; secrets are only injected at boot.
+
+## Rotation
+
+Rotating an age recipient (departure, key compromise):
+
+1. Remove the recipient's public key from `creation_rules.age` in `.sops.yaml`.
+2. Run `sops updatekeys` on every encrypted file:
+
+   ```bash
+   find . \( -path './secrets/*' -o -name '*.sops.yaml' -o -name '*.sops.json' -o -name '*.sops.env' \) -print0 \
+     | xargs -0 -I {} sops updatekeys --yes {}
+   ```
+
+3. Commit the re-encrypted files and the updated `.sops.yaml` in a single PR.
+
+Rotating an actual secret value (e.g., regenerated DSN):
+
+1. `sops <path>` to open the file in your editor.
+2. Replace the value, save, and commit. SOPS handles the re-encryption transparently.
+
+## Out of scope here
+
+- **Dynamic / short-lived secrets** (per-request tokens, database creds rotated every 24 h) — that's a HashiCorp Vault story or a cloud-KMS-backed STS, not in scope for the v1 secrets refactor.
+- **HSM-backed keys** — same; track separately if compliance requires it.
+- **Cross-environment secret promotion** (dev → staging → prod) — for now, each environment has its own age recipient set and its own encrypted files under `secrets/<env>/`.

--- a/docs/security/verifying-releases.md
+++ b/docs/security/verifying-releases.md
@@ -72,4 +72,4 @@ Use `$IMAGE@$DIGEST` in `docker-compose.yml`, Helm values, Kubernetes manifests,
 
 ## Reporting a verification failure
 
-If `cosign verify` or `slsa-verifier verify-artifact` fails on a wheel or image we appear to have released, **do not run the artefact**. Report to **security@zakuro.ai** (see [`SECURITY.md`](../../SECURITY.md)) — a verification failure on a legitimate Zakuro release is either a supply-chain incident or a packaging bug, and we treat both at the same priority.
+If `cosign verify` or `slsa-verifier verify-artifact` fails on a wheel or image we appear to have released, **do not run the artefact**. Report to **security@zakuro.ai** — a verification failure on a legitimate Zakuro release is either a supply-chain incident or a packaging bug, and we treat both at the same priority.

--- a/scripts/sops-decrypt-runtime.sh
+++ b/scripts/sops-decrypt-runtime.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+# scripts/sops-decrypt-runtime.sh
+#
+# Runtime entrypoint shim: decrypt every secret file referenced by
+# ZAKURO_SOPS_FILES (a colon-separated list) into tmpfs, source the
+# resulting dotenv into the current shell, then exec the original
+# command. Closes the deploy half of #118.
+#
+# Usage in a Dockerfile or compose:
+#     ENV ZAKURO_SOPS_FILES=/secrets/sentry-dsn.sops.env:/secrets/s3.sops.env
+#     ENTRYPOINT ["/usr/local/bin/sops-decrypt-runtime.sh", "python", "-m", "zakuro.worker.server"]
+#
+# The age private key must already be available — typically:
+#   - k8s: mounted from a Secret at /var/run/secrets/age/keys.txt
+#   - dev: ~/.config/sops/age/keys.txt
+# SOPS picks it up via SOPS_AGE_KEY_FILE.
+
+set -eu
+
+: "${SOPS_AGE_KEY_FILE:=/var/run/secrets/age/keys.txt}"
+export SOPS_AGE_KEY_FILE
+
+if [ -n "${ZAKURO_SOPS_FILES:-}" ]; then
+  if ! command -v sops >/dev/null 2>&1; then
+    echo "sops-decrypt-runtime: \`sops\` binary not found on PATH" >&2
+    exit 1
+  fi
+  if [ ! -r "$SOPS_AGE_KEY_FILE" ]; then
+    echo "sops-decrypt-runtime: age key file unreadable at $SOPS_AGE_KEY_FILE" >&2
+    exit 1
+  fi
+
+  OLD_IFS="$IFS"
+  IFS=":"
+  for f in $ZAKURO_SOPS_FILES; do
+    if [ ! -f "$f" ]; then
+      echo "sops-decrypt-runtime: secret file not found: $f" >&2
+      exit 1
+    fi
+    # Decrypt into a tmpfs path and source it. We do not write to disk.
+    # shellcheck disable=SC2046
+    set -a
+    eval "$(sops --decrypt "$f")"
+    set +a
+  done
+  IFS="$OLD_IFS"
+fi
+
+# Hand control to the actual command — exec replaces the shim so signals
+# (SIGTERM from k8s) reach the worker / broker directly.
+exec "$@"

--- a/secrets/README.md
+++ b/secrets/README.md
@@ -1,0 +1,3 @@
+# Encrypted secret files live here. Drop a YAML/JSON/env file under
+# secrets/, encrypt with `sops --encrypt --in-place <file>`.
+# See ../docs/secrets.md for the developer workflow.


### PR DESCRIPTION
Closes [#118](https://github.com/zakuro-ai/zakuro/issues/118). User picked SOPS + age over Vault / K8s Secrets / env+KMS — git-native, lightest ops, no cluster-side orchestrator to maintain.

## What lands

| Path | Role |
|---|---|
| \`.sops.yaml\` | Creation rules. Covers \`secrets/**\` and \`*.sops.{yaml,json,env}\`. Only keys *named* like a secret (\`data\` / \`password\` / \`token\` / \`*_KEY\` / \`*_TOKEN\` / \`*_DSN\` / ...) are encrypted in place; structural metadata stays in plaintext so files remain reviewable. Recipient list is a placeholder until first real age key is added. |
| \`docs/secrets.md\` | End-to-end developer workflow — install tooling, generate age key, get added to the recipient list, edit/create/rotate secrets, CI behaviour, runtime decryption flow. |
| \`scripts/sops-decrypt-runtime.sh\` | Entrypoint shim invoked by the worker / broker images at boot. Reads colon-separated \`ZAKURO_SOPS_FILES\`, decrypts each into the process env via \`eval $(sops --decrypt ...)\`, then \`exec\`s the real command. Uses \`SOPS_AGE_KEY_FILE\` (default \`/var/run/secrets/age/keys.txt\`) so the age private key never lands on disk inside the image. |
| \`secrets/README.md\` | Placeholder pointing at \`docs/secrets.md\`. |
| \`.github/workflows/sast.yml\` | New \`sops-encryption-check\` job — refuses to merge if a file matching the secret naming convention is committed in plaintext. **Strict**, no \`continue-on-error\`. |

## Why CI is strict for this lane

Every other lane I introduced (\`pip-audit\`, \`Semgrep\`, \`trivy\`, etc.) is report-only on introduction. This one is the exception: a leaked secret is the one thing we do not want to ratchet later. I tested the rule locally against a synthetic \`secrets/UNENCRYPTED-TEST.sops.yaml\` — it triggers \`::error file=...::file matches the secret naming convention but does not appear to be SOPS-encrypted\` exactly as intended.

## Manual follow-up after merge

1. Generate the **first real age key** for the team:

   \`\`\`bash
   age-keygen -o ~/.config/sops/age/keys.txt
   \`\`\`

2. Add its public key to \`.sops.yaml\` (replacing the placeholder).
3. Store the corresponding private key:
   - In the \`release\` GitHub Actions environment as \`SOPS_AGE_KEY\` for CI.
   - In each worker / broker pod as a K8s Secret mounted at \`/var/run/secrets/age/keys.txt\` (for runtime decryption).
4. **Migrate the existing Sentry DSN** off the bare env-var path: create \`secrets/sentry-dsn.sops.env\` with \`SENTRY_DSN=...\`, encrypt, drop the corresponding repo secret. \`zakuro.observability.init_sentry\` already reads from the env so the runtime shim handles the rest.

## Intentionally out of scope

Documented in \`docs/secrets.md\`:

- **Dynamic / short-lived secrets** (Vault, STS) — separate ticket if compliance requires.
- **HSM-backed keys** — same.
- **Cross-environment promotion tooling** — for now each environment has its own age recipient set and its own files under \`secrets/<env>/\`.

## Test plan

- [ ] CI green on this PR (including the new \`sops-encryption-check\` lane — should pass because there are no encrypted files yet).
- [ ] After merge: drop a plaintext file at \`secrets/test.sops.yaml\` in a test PR and confirm the lane fails with the expected error.

Closes #118