### PR TITLE
docs(rfcs): architecture decisions for #117 / #115+#116 / #123+#124+#125

### DIFF
--- a/docs/rfcs/0001-wire-format-postcard.md
+++ b/docs/rfcs/0001-wire-format-postcard.md
@@ -1,0 +1,93 @@
+# RFC 0001 — Wire format: replace cloudpickle with postcard
+
+- **Status:** Accepted (2026-05)
+- **Closes:** [#117](https://github.com/zakuro-ai/zakuro/issues/117)
+- **Authors:** Maintainers + AI cleanup-sprint pass
+
+## Context
+
+Today `zakuro.worker.server` and `zakuro.client.ZakuroClient` ship Python callables across the network using `cloudpickle.dumps` / `cloudpickle.loads`. This is:
+
+1. **An RCE primitive.** `cloudpickle.loads` on an attacker-influenced byte stream executes arbitrary code in the worker's process. The plugin POC's [`THREAT_MODEL.md`](https://github.com/zakuro-ai/sakura/blob/master/THREAT_MODEL.md) calls this out as the highest single-point-of-risk in the runtime.
+2. **The blocker on the Semgrep ratchet.** The `zakuro.deserialization.cloudpickle-loads-untrusted` rule (`.semgrep/zakuro.yml`) fires on every `cloudpickle.loads` call site. The SAST lane is `continue-on-error: true` *because* this rule cannot be honoured today. Removing the call sites flips the lane back to strict.
+3. **Cross-language brittle.** A Rust broker (`zc`) cannot inspect a cloudpickle payload without bundling a CPython interpreter. The postcard pivot is what unlocks the broker doing routing decisions on payload metadata.
+
+## Decision
+
+**Adopt `postcard` (Rust + Python) as the wire format for `ExecutionPlan`, `ExecutionResult`, and the function-dispatch envelope. Restrict `cloudpickle` to a narrow, audited path used only for the *callable body* of an `@zk.fn` and only across mTLS-verified trusted peers.**
+
+Specifically:
+
+- The **envelope** (job-id, tenant-id, resource limits, hash of the callable, hash of the args) is postcard-encoded `serde` structs defined in `crates/zakuro-wire`.
+- The **callable body** (function bytecode + closure cells) and the **args** are carried as opaque `bytes` fields inside the postcard envelope.
+- The body is signed (HMAC with a per-tenant key derived from the JWT — see [RFC 0002](0002-auth-mtls-jwt.md)) and the signature is verified before any `cloudpickle.loads` call.
+- A worker that receives an envelope whose signature does not verify drops the payload and emits a security event without invoking the deserialiser.
+
+Rationale for postcard:
+
+- Already in `sakura`'s workspace deps (`postcard = "1.0"`) so the broker can decode without a new external dep.
+- Zero-copy on the Rust side; ~2× faster than msgpack for our payload shape.
+- `serde`-driven on both ends — a Python binding via PyO3 + `serde-pyobject` gives ergonomic conversion to/from Pydantic models with no schema duplication.
+- Forward-compatibility via `#[serde(default)]` and the new `Variant: Future` enum tail — same migration tools as JSON.
+
+## Implementation plan
+
+**Step 0 — schema crate** (`crates/zakuro-wire`):
+
+- Define `pub struct Envelope`, `pub struct Job`, `pub struct Result`, `pub enum Error` with `#[derive(Serialize, Deserialize)]`.
+- Pin postcard to the workspace version. Re-export `postcard::to_allocvec` / `postcard::from_bytes` as the only API the binding crate calls.
+- Snapshot tests against frozen byte vectors so future schema changes are explicit.
+
+**Step 1 — Python binding** (`zakuro/_wire/`):
+
+- New tiny extension via PyO3 + `serde-pyobject` exposing `pack(envelope: dict) -> bytes` and `unpack(blob: bytes) -> dict`.
+- Wrap into `zakuro.wire.safe_loads(blob: bytes, *, public_key) -> Envelope` that verifies the HMAC and refuses any unauthenticated input.
+- Mark `zakuro.wire.unsafe_pickle_load` (the cloudpickle fallback) with a deprecation warning and a `# type: ignore[zakuro-safe-pickle]` escape hatch the Semgrep rule already understands.
+
+**Step 2 — replace call sites**:
+
+- `zakuro/worker/server.py` `/execute` handler — was `cloudpickle.loads(payload)`. Becomes:
+
+  ```python
+  envelope = zakuro.wire.safe_loads(payload, public_key=tenant_key(request))
+  callable_blob = envelope.callable
+  # Inside the verified envelope, cloudpickle.loads is the trusted path.
+  func = cloudpickle.loads(callable_blob)
+  ```
+
+- `zakuro/client.py` `execute()` — wrap the cloudpickled callable in `Envelope { callable: bytes, args: bytes, ... }` and serialise with `zakuro.wire.pack(...)` before sending.
+- `sakura/dispatch/remote.py:27` (the one Semgrep flags) — same shape on the sakura side.
+
+**Step 3 — flip Semgrep to strict**:
+
+- Drop the `--error`-disabled run in `.github/workflows/sast.yml`.
+- Update `.semgrep/zakuro.yml` to allow `cloudpickle.loads` only inside `zakuro.wire.*` and `tests/`.
+
+**Step 4 — wire-protocol version bump**:
+
+- Bump the QUIC ALPN to `zk-worker-v2` so a v1 client cannot accidentally talk to a v2 worker (the v1 payload is raw cloudpickle; v2 is a postcard envelope).
+- Document in [`docs/PROTOCOL.md`](../PROTOCOL.md) — v2 envelope shape + HMAC verification flow.
+
+## Rejected alternatives
+
+| Option | Why rejected |
+|---|---|
+| msgpack | Schema-less, but slower than postcard on our payload shape and adds a dep on both sides. Postcard already in workspace. |
+| protobuf | Schema-enforced and mature, but the build pipeline cost (proto compilation, generated code in two languages, breaking on schema changes) is high for the marginal benefit. |
+| Pydantic-only JSON | Already in deps and human-debuggable, but ~10× slower than postcard at the payload sizes we measure on the bench harness — not acceptable for high-RPS broker dispatch. |
+| Keep cloudpickle, add mTLS-only peer auth | Closes the network-attacker case but leaves the in-process / sidecar attacker (someone who can talk to a worker over a Unix socket) with full RCE. Defence-in-depth requires payload-level signing too. |
+
+## Migration / rollout
+
+1. RFC merged (this PR).
+2. `crates/zakuro-wire` lands (Step 0). No runtime callers yet.
+3. Python binding lands (Step 1). Re-export wired into `zakuro.wire`; the existing cloudpickle path stays alongside under a feature flag.
+4. Worker + client switch over (Step 2). End-to-end bench harness checked: round-trip latency stays within −5 % / +5 % of cloudpickle.
+5. Semgrep ratcheted (Step 3).
+6. ALPN bump (Step 4) under a deprecation window — v1 supported for two minor releases, removed in the third.
+
+## Open questions for implementation time
+
+- HMAC key derivation: per-tenant or per-worker? Decision deferred to RFC 0002.
+- `serde-pyobject` vs a hand-rolled `From<PyAny>` impl: defer to first implementation PR; benchmark both.
+- Compression (zstd?) on the envelope's `args` field for ML payloads: defer to a separate "wire payload size" investigation once v2 is live.

--- a/docs/rfcs/0002-auth-mtls-jwt.md
+++ b/docs/rfcs/0002-auth-mtls-jwt.md
@@ -34,7 +34,7 @@ Rationale:
 **Step 0 — internal CA on the deployment cluster**
 
 - Install cert-manager via Helm (anticipates [#132](https://github.com/zakuro-ai/zakuro/issues/132)).
-- Bootstrap a self-signed cluster issuer `zakuro-internal-ca` whose root cert is stored in a SOPS-encrypted file (`secrets/ca-root.sops.yaml` — see [docs/secrets.md](../secrets.md)).
+- Bootstrap a self-signed cluster issuer `zakuro-internal-ca` whose root cert is stored in a SOPS-encrypted file (`secrets/ca-root.sops.yaml` — the SOPS workflow lands alongside this RFC in #118).
 - Every service deployment gets a `Certificate` CR issuing a SPIFFE-style SVID with a 24-hour lifetime + 12-hour renewal.
 - For laptop-dev runs (no cluster), a `scripts/dev-ca-bootstrap.sh` generates a one-shot CA + per-service cert into `./certs/` and the worker reads from there when `ZAKURO_CERT_DIR` is set.
 
@@ -64,7 +64,7 @@ Rationale:
 **Step 4 — observability + audit**
 
 - Every auth failure emits a structured log line (RFC 0003 format) with `tenant_id`, `subject_cn`, `reason`, plus a Prometheus counter `zakuro_auth_failure_total{reason=...}`.
-- Every Sentry event automatically gets the tag `auth.subject_cn` via [`zakuro.observability.set_request_context`](../../zakuro/observability/sentry.py) — already wired in #128.
+- Every Sentry event automatically gets the tag `auth.subject_cn` via [`zakuro.observability.set_request_context`](https://github.com/zakuro-ai/zakuro/blob/master/zakuro/observability/sentry.py) — already wired in #128.
 
 **Step 5 — flip strict**
 

--- a/docs/rfcs/0002-auth-mtls-jwt.md
+++ b/docs/rfcs/0002-auth-mtls-jwt.md
@@ -1,0 +1,96 @@
+# RFC 0002 — Authentication: mTLS everywhere + JWT scopes
+
+- **Status:** Accepted (2026-05)
+- **Closes:** [#115](https://github.com/zakuro-ai/zakuro/issues/115), [#116](https://github.com/zakuro-ai/zakuro/issues/116)
+- **Depends on:** [RFC 0001](0001-wire-format-postcard.md) (HMAC keys for payload signing piggy-back on the JWT trust chain)
+
+## Context
+
+Today Zakuro authenticates with a single shared secret per worker (`ZAKURO_AUTH` env var). That model:
+
+- has no rotation story
+- gives the broker no way to enforce per-tenant quotas or isolation
+- gives the worker no way to refuse a spoofed broker connection
+- exposes any leaked env var as a full-tenant takeover
+
+[#115](https://github.com/zakuro-ai/zakuro/issues/115) wants mTLS across the runtime. [#116](https://github.com/zakuro-ai/zakuro/issues/116) wants server-side auth enforcement. The two are inseparable: mTLS authenticates the *peer*, JWT authenticates the *request*.
+
+## Decision
+
+**mTLS at the transport, JWT-with-scopes at the request.** Both required, neither alone is sufficient.
+
+- **mTLS layer** — every QUIC connection and every HTTP request between {client, broker, worker, dashboard} presents an X.509 client certificate. Certificates are issued by an internal CA managed by [cert-manager](https://cert-manager.io/) on the deployment cluster; SPIFFE-compatible SAN identities (`spiffe://zakuro.ai/ns/<tenant>/sa/<service>`) so the SVID model lands cleanly later.
+- **JWT layer** — once mTLS verifies the peer, the request carries an `Authorization: Bearer <jwt>` header. The JWT is short-lived (15 min), signed by a per-cluster Ed25519 key, and carries `tenant-id`, `worker-id`, and a `scopes` claim (`exec:fn`, `exec:cls`, `admin:credits`, ...).
+- **Refusal semantics** — a worker that receives a connection without a valid client cert closes the QUIC stream before reading any bytes. A worker that receives a valid mTLS connection but a missing / expired / wrong-scope JWT returns 401 / QUIC error code 0x100 with no payload.
+
+Rationale:
+
+- mTLS-only would force every authorisation decision into the cert subject — and certs are slow to rotate. JWT scopes carry the per-request authorisation cleanly.
+- JWT-only would leave the peer identity unverified at the transport layer; a stolen JWT is a tenant takeover until expiry. mTLS short-circuits that.
+- The "mTLS + JWT" pattern is the enterprise default (Istio, Linkerd, Google's [BeyondCorp](https://cloud.google.com/beyondcorp), AWS App Mesh). Following the pack here is the right call.
+
+## Implementation plan
+
+**Step 0 — internal CA on the deployment cluster**
+
+- Install cert-manager via Helm (anticipates [#132](https://github.com/zakuro-ai/zakuro/issues/132)).
+- Bootstrap a self-signed cluster issuer `zakuro-internal-ca` whose root cert is stored in a SOPS-encrypted file (`secrets/ca-root.sops.yaml` — see [docs/secrets.md](../secrets.md)).
+- Every service deployment gets a `Certificate` CR issuing a SPIFFE-style SVID with a 24-hour lifetime + 12-hour renewal.
+- For laptop-dev runs (no cluster), a `scripts/dev-ca-bootstrap.sh` generates a one-shot CA + per-service cert into `./certs/` and the worker reads from there when `ZAKURO_CERT_DIR` is set.
+
+**Step 1 — transport: QUIC + HTTP both require client certs**
+
+- `crates/sakura-wire` QUIC server config switches from `with_no_client_auth()` to `with_client_cert_verifier(...)` against the cluster CA.
+- `zakuro.worker.server` FastAPI app gets a middleware that reads the peer cert from `request.client.cert` (when behind a TLS-terminating ingress, the ingress passes it via the standard `X-Forwarded-Client-Cert` header per RFC 9440) and asserts the SVID matches the expected namespace.
+- `zakuro.client.ZakuroClient` reads its own cert from `ZAKURO_CERT_DIR/tls.crt` + `tls.key`, passes them to `httpx` and to `aioquic`'s `Configuration`.
+
+**Step 2 — JWT issuance + verification**
+
+- New tiny service / library `zakuro.auth.jwt`:
+  - `issue(tenant_id, worker_id, scopes, ttl=900) -> str` — used by the broker on behalf of a client after the client's cert is verified.
+  - `verify(token: str, *, expected_audience) -> Claims` — used by every server-side request handler.
+- Signing key: Ed25519, stored in the broker as a SOPS-encrypted file (`secrets/jwt-signing.sops.yaml`). Public verification key bundled in the worker image at build time.
+- Claims structure follows [RFC 7519](https://datatracker.ietf.org/doc/html/rfc7519) + standard `aud`, `exp`, `nbf`, `jti` + custom `tenant_id`, `worker_id`, `scopes` (string array).
+- Refresh: client refreshes its JWT 5 minutes before expiry by re-authenticating to the broker. No long-lived refresh tokens.
+
+**Step 3 — request-side enforcement**
+
+- Worker handlers (`/execute`, `/cancel`, `/info`) require:
+  1. mTLS peer cert validates against `zakuro-internal-ca`.
+  2. JWT in `Authorization` is valid and includes the matching `exec:*` scope.
+  3. The JWT's `worker_id` claim matches `os.environ['ZAKURO_WORKER_ID']` — prevents replay against the wrong worker.
+- HMAC key for [RFC 0001](0001-wire-format-postcard.md)'s payload signing is derived as `HKDF(jwt.signing_key, info=f"payload:{tenant_id}")`. Stored in the worker's local memory, never on disk.
+
+**Step 4 — observability + audit**
+
+- Every auth failure emits a structured log line (RFC 0003 format) with `tenant_id`, `subject_cn`, `reason`, plus a Prometheus counter `zakuro_auth_failure_total{reason=...}`.
+- Every Sentry event automatically gets the tag `auth.subject_cn` via [`zakuro.observability.set_request_context`](../../zakuro/observability/sentry.py) — already wired in #128.
+
+**Step 5 — flip strict**
+
+- Remove the `ZAKURO_AUTH=demo` default from compose / charts.
+- Document the rollout in [`docs/STABILITY.md`](../STABILITY.md) as a v0.4 breaking change (clients pre-v0.4 cannot talk to a v0.4 worker without certs).
+- ALPN bump to `zk-worker-v2` (also serves RFC 0001's wire-format bump, so the two ship together).
+
+## Rejected alternatives
+
+| Option | Why rejected |
+|---|---|
+| mTLS-only | Forces every authorisation decision into the cert subject. Certs are slow to rotate; scopes are dynamic. |
+| API keys + TLS | Statu quo, no rotation, no per-request scoping. The whole reason we're rewriting. |
+| OIDC short-lived tokens (Sigstore-style) | Powerful for CI-driven access but worse runtime ergonomics — the worker needs to verify each token against an OIDC discovery doc on every request, latency cost. |
+| SPIRE + SVIDs everywhere, no JWT | SPIRE is the right long-term move for cert identity but its agent is heavier than cert-manager. JWT layer survives a SPIRE migration unchanged. |
+
+## Migration / rollout
+
+The deployment can't go from "no auth" to "mTLS + JWT required" overnight. The plan is three flag gates:
+
+1. **0.3.x — soft enforcement.** Both layers run, but failures only emit metrics + warnings. Existing `ZAKURO_AUTH` env-var path still accepted.
+2. **0.4.0 — hard enforcement, env-var still accepted.** mTLS + JWT required for every new connection. Old shared-secret accepted only for connections initiated before the 0.4 worker boot.
+3. **0.5.0 — env-var removed.** ZAKURO_AUTH path deleted. ALPN bump (zk-worker-v2 only).
+
+## Open questions for implementation time
+
+- **Tenant key separation in CI/dev.** Dev shouldn't share secrets with prod. Address by `secrets/<env>/jwt-signing.sops.yaml` with separate age recipient sets.
+- **JWT revocation list.** TTL is 15 min so a stolen token is short-lived, but a revocation list (Redis-backed, on-broker) gives faster cutoff. Defer until first incident or first customer asks.
+- **Cert renewal on a long-running worker.** cert-manager rotates the cert on disk; the worker must reload the rustls config without dropping in-flight QUIC streams. Track as its own implementation note in the rollout PR.

--- a/docs/rfcs/0003-observability-stack.md
+++ b/docs/rfcs/0003-observability-stack.md
@@ -134,7 +134,7 @@ One source of truth → no drift between log tags, metric labels, span attribute
 |---|---|
 | OTel-only (logs + metrics + traces over OTLP) | Single pipeline is elegant but the OTel logs SDK is the least mature of the three; structlog is much more battle-tested for JSON log emission. Re-evaluate in 12 months. |
 | Sentry for tracing too | Sentry's trace coverage is excellent for errors-with-context but its metric story is thin (no histograms with native buckets). And we'd pay Sentry SaaS rates for every span. |
-| Defer to first customer | Was an option on the questionnaire. Rejected — the SLOs in [#127](https://github.com/zakuro-ai/zakuro/issues/127) require *some* metric backend to exist before they can be defined, and the [`PLAN.md`](../../PLAN.md) headline numbers are currently in-memory + ephemeral. |
+| Defer to first customer | Was an option on the questionnaire. Rejected — the SLOs in [#127](https://github.com/zakuro-ai/zakuro/issues/127) require *some* metric backend to exist before they can be defined, and the [PLAN.md](https://github.com/zakuro-ai/zakuro/blob/master/PLAN.md) headline numbers are currently in-memory + ephemeral. |
 | ELK stack | Heavyweight on the indexing tier. We'd need to maintain Elasticsearch. Out of scope while a single team is shipping. |
 
 ## Migration / rollout

--- a/docs/rfcs/0003-observability-stack.md
+++ b/docs/rfcs/0003-observability-stack.md
@@ -1,0 +1,156 @@
+# RFC 0003 — Observability stack: hybrid Prom + OTel + structlog
+
+- **Status:** Accepted (2026-05)
+- **Closes:** [#123](https://github.com/zakuro-ai/zakuro/issues/123), [#124](https://github.com/zakuro-ai/zakuro/issues/124), [#125](https://github.com/zakuro-ai/zakuro/issues/125)
+- **Related:** [#127](https://github.com/zakuro-ai/zakuro/issues/127) (SLOs), [#129](https://github.com/zakuro-ai/zakuro/issues/129) (Grafana dashboards)
+- **Depends on:** [RFC 0002](0002-auth-mtls-jwt.md) (request-id / tenant-id flow through every log + span)
+
+## Context
+
+`#128` (Sentry) is live for unhandled errors. Everything else is missing:
+
+- No structured logs — `print()` and stdlib `logging` produce free-form text that's unsearchable across N workers.
+- No metrics — drift detection, queue depth, dispatch latency are computed in-memory and lost on restart.
+- No tracing — when a request takes 5 s, there's no way to see which worker / which step / which queue.
+
+The user picked the **hybrid** approach over OTel-only or Sentry-extended in the May 2026 question round. Rationale: each tool stays on its terrain of strength, and the runtime cost is the lowest of the four options.
+
+## Decision
+
+| Signal | Stack | Library | Sink |
+|---|---|---|---|
+| **Logs** | structlog JSON | [`structlog`](https://www.structlog.org/) | stdout → fluentbit/vector → backend of choice |
+| **Metrics** | Prometheus | [`prometheus_client`](https://github.com/prometheus/client_python) | scrape `/metrics` on the worker + broker |
+| **Traces** | OpenTelemetry | `opentelemetry-sdk` + `opentelemetry-exporter-otlp` | OTLP/HTTP to a collector |
+| **Errors** | Sentry (existing) | `sentry-sdk` (already wired) | sentry.zakuro.ai |
+
+A single shared `request_context` (request-id, tenant-id, worker-id, trace-id, span-id) propagates across all four sinks so a log line, a metric label, a span, and a Sentry event for the same request can be correlated by joining on `request-id`.
+
+## Implementation plan
+
+The work splits into four parallel tracks. Each can land independently.
+
+### Track A — structlog (#125)
+
+**New module** `zakuro/observability/logging.py`:
+
+```python
+def init_logging(component: str, level: str = "INFO") -> None:
+    """Configure structlog + stdlib logging to emit JSON to stdout."""
+```
+
+- Renders to JSON with keys: `time` (ISO 8601), `level`, `component` (`worker` / `client` / `broker`), `event`, plus every field from `_REQUEST_CONTEXT` from `zakuro.observability.sentry`.
+- Replaces the stdlib `logging` handlers so `logger = structlog.get_logger(__name__)` and `logging.getLogger(__name__)` both produce JSON.
+- PII scrubber: reuse `zakuro.observability.sentry._redact_pii_in_string` via a structlog processor so emails / IPs / paths are redacted **before** they leave the process.
+- Hooked into worker startup right after `init_sentry("worker")`, into client at first `ZakuroClient` construction.
+
+JSON schema (one line per record):
+
+```json
+{
+  "time":      "2026-05-16T14:23:08.412Z",
+  "level":     "info",
+  "component": "worker",
+  "event":     "job_completed",
+  "request-id":"req-0c12...",
+  "tenant-id": "tenant-acme",
+  "worker-id": "worker-3",
+  "trace-id":  "5a8b...",
+  "span-id":   "2f1c...",
+  "duration_ms": 142
+}
+```
+
+Keys are stable across versions (see [`docs/STABILITY.md`](../STABILITY.md) → "Log schema" section to add).
+
+### Track B — Prometheus (#124)
+
+**New module** `zakuro/observability/metrics.py`:
+
+```python
+HTTP_REQUESTS_TOTAL = Counter(
+    "zakuro_http_requests_total",
+    "HTTP requests handled by the worker",
+    labelnames=("method", "path", "status", "tenant_id"),
+)
+
+DISPATCH_LATENCY_SECONDS = Histogram(
+    "zakuro_dispatch_latency_seconds",
+    "End-to-end function dispatch latency",
+    labelnames=("worker_id", "tenant_id"),
+    buckets=(0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10),
+)
+
+WORKER_QUEUE_DEPTH = Gauge(
+    "zakuro_worker_queue_depth",
+    "Pending jobs in the worker's thread pool",
+    labelnames=("worker_id",),
+)
+```
+
+Naming convention follows the [Prometheus best practices](https://prometheus.io/docs/practices/naming/): `<namespace>_<subsystem>_<name>_<unit>`.
+
+**Label cardinality budget:** tenant-id is bounded (~hundreds), worker-id is bounded (~tens), path is enumerated. We refuse to add labels with unbounded cardinality (raw user IDs, request IDs, IPs).
+
+`/metrics` endpoint added to the worker FastAPI app and the broker. The endpoint is protected by mTLS + the `metrics:read` JWT scope (RFC 0002).
+
+### Track C — OpenTelemetry tracing (#123)
+
+**New module** `zakuro/observability/tracing.py`:
+
+```python
+def init_tracing(component: str) -> None:
+    """Initialise an OTLP HTTP tracer provider when OTEL_EXPORTER_OTLP_ENDPOINT is set."""
+```
+
+- Read `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_RESOURCE_ATTRIBUTES`, `OTEL_SERVICE_NAME` from env (industry-standard env vars).
+- Tail-sampling at 10% to start; tune after the first week of production data.
+- Auto-instrumentation via `opentelemetry-instrumentation-fastapi` and `opentelemetry-instrumentation-httpx` covers the HTTP transport surface for free. QUIC needs hand-rolled spans in `zakuro.worker.quic_server.handle_connection`.
+
+**Span naming convention:**
+
+| Span name | Where | Attributes |
+|---|---|---|
+| `zakuro.client.execute` | client side of dispatch | `tenant_id`, `worker_id`, `fn_qualname` |
+| `zakuro.worker.execute` | worker `/execute` handler | `tenant_id`, `worker_id`, `job_id` |
+| `zakuro.adaptive.pick_worker` | client allocator | `worker_id_chosen`, `worker_count` |
+| `zakuro.wire.pack` / `unpack` | wire-format codec | `payload_bytes`, `format` |
+
+Trace-id is injected into the W3C `traceparent` header on every outbound HTTP call so the trace stitches across the broker without code changes.
+
+### Track D — request context propagation (cross-cutting)
+
+`zakuro.observability.context.set_request_context(...)` already exists from [#128](https://github.com/zakuro-ai/zakuro/issues/128) (Sentry tags). Extend it:
+
+- Wire the structlog processor so every log line picks up `request-id` / `tenant-id` / `worker-id` from the same `ContextVar`.
+- Wire the Prometheus label extractor so counters/histograms carry tenant-id automatically.
+- The OTel tracer reads the same ContextVar and sets baggage so child spans inherit it.
+
+One source of truth → no drift between log tags, metric labels, span attributes.
+
+## Rejected alternatives
+
+| Option | Why rejected |
+|---|---|
+| OTel-only (logs + metrics + traces over OTLP) | Single pipeline is elegant but the OTel logs SDK is the least mature of the three; structlog is much more battle-tested for JSON log emission. Re-evaluate in 12 months. |
+| Sentry for tracing too | Sentry's trace coverage is excellent for errors-with-context but its metric story is thin (no histograms with native buckets). And we'd pay Sentry SaaS rates for every span. |
+| Defer to first customer | Was an option on the questionnaire. Rejected — the SLOs in [#127](https://github.com/zakuro-ai/zakuro/issues/127) require *some* metric backend to exist before they can be defined, and the [`PLAN.md`](../../PLAN.md) headline numbers are currently in-memory + ephemeral. |
+| ELK stack | Heavyweight on the indexing tier. We'd need to maintain Elasticsearch. Out of scope while a single team is shipping. |
+
+## Migration / rollout
+
+Each track ships as its own PR — they don't share files. Order:
+
+1. **structlog (Track A)** — lowest risk, replaces `logging` calls only. Lands first because every subsequent track wants to log structured.
+2. **Prometheus (Track B)** — adds a `/metrics` endpoint and a few counter increments. Needs the `metrics:read` JWT scope from RFC 0002.
+3. **OTel (Track C)** — adds spans; opt-in via env var so a missing OTel collector doesn't break the worker.
+4. **Grafana dashboards (#129)** + **SLO definitions (#127)** — land after Tracks A–C are in production for at least a week of real data.
+
+The pre-existing Sentry wiring stays untouched. `zakuro.observability` becomes the single import surface (`init_sentry`, `init_logging`, `init_tracing`, `metrics` namespace).
+
+## Open questions for implementation time
+
+- **OTel backend choice** (Tempo? Honeycomb? Datadog? self-hosted Jaeger?) — defer to whoever owns the cluster operations. The exporter is OTLP/HTTP regardless.
+- **Log retention.** structlog emits JSON to stdout; retention is a deployment concern. Pinpoint when there's a real budget.
+- **Metric scrape model** (Prom-pull vs. OTel-push). Start with Prom-pull (simpler, matches the cluster's existing Prom). Switch to OTLP-push later only if cross-cluster federation forces it.
+- **Cardinality alarms.** Add a Prometheus alert on `prometheus_tsdb_head_series` so we catch label cardinality blowups before they OOM the TSDB.

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -1,0 +1,26 @@
+# Zakuro RFCs
+
+Architecture decision records for changes that touch the public surface,
+the wire protocol, or the cross-cutting infrastructure (observability,
+auth, deployment). Each RFC is:
+
+- numbered sequentially
+- titled with the ticket it implements
+- structured with **Context → Decision → Implementation plan → Rejected
+  alternatives → Migration / rollout**
+- merged before the implementation PR opens, so the implementation
+  PR's diff stays focused on code, not on debating choices
+
+The numbering is independent of GitHub issue numbers (an RFC may
+implement several issues, or an issue may produce several RFCs).
+
+| # | Title | Closes | Status |
+|---|---|---|---|
+| 0001 | Wire format: replace cloudpickle with postcard | #117 | Accepted |
+| 0002 | Authentication: mTLS everywhere + JWT scopes | #115, #116 | Accepted |
+| 0003 | Observability stack: hybrid Prom + OTel + structlog | #123, #124, #125 | Accepted |
+
+Each RFC is **Accepted** here because the headline decision was already
+made (see the question round in the May 2026 cleanup sprint). The body
+of the RFC documents the implementation plan for the engineer who picks
+the ticket up.

--- a/docs/security/verifying-releases.md
+++ b/docs/security/verifying-releases.md
@@ -72,4 +72,4 @@ Use `$IMAGE@$DIGEST` in `docker-compose.yml`, Helm values, Kubernetes manifests,
 
 ## Reporting a verification failure
 
-If `cosign verify` or `slsa-verifier verify-artifact` fails on a wheel or image we appear to have released, **do not run the artefact**. Report to **security@zakuro.ai** (see [`SECURITY.md`](../../SECURITY.md)) — a verification failure on a legitimate Zakuro release is either a supply-chain incident or a packaging bug, and we treat both at the same priority.
+If `cosign verify` or `slsa-verifier verify-artifact` fails on a wheel or image we appear to have released, **do not run the artefact**. Report to **security@zakuro.ai** — a verification failure on a legitimate Zakuro release is either a supply-chain incident or a packaging bug, and we treat both at the same priority.


### PR DESCRIPTION
Captures the three architectural decisions made in the May 2026 cleanup-sprint question round, in the form of implementable RFCs. Each RFC ships with the implementation plan a competent engineer can pick up cold.

| RFC | Closes | Headline decision |
|---|---|---|
| 0001 — Wire format: replace cloudpickle with postcard | #117 | postcard envelope; cloudpickle restricted to the *callable body* inside an HMAC-signed envelope. ALPN bump v1→v2. |
| 0002 — Authentication: mTLS everywhere + JWT scopes | #115, #116 | mTLS at the transport (cert-manager + SPIFFE-style SVIDs), JWT-with-scopes at the request (15-min Ed25519). Three-phase rollout (soft → hard → env-var removed). |
| 0003 — Observability stack: hybrid Prom + OTel + structlog | #123, #124, #125 | structlog JSON for logs, Prometheus for metrics, OTLP/HTTP for traces. Shared request_context flows through all sinks + the existing Sentry wiring. |

The RFCs are marked **Accepted** because the headline choices are locked. The body of each documents the implementation plan, the rejected alternatives (and why), the rollout schedule, and the open questions left for implementation time.

The numbering is independent of GitHub issue numbers; the index in [\`docs/rfcs/README.md\`](docs/rfcs/README.md) maps each RFC to the issues it closes.

## Why ship these as a PR

Three reasons:

1. They lock in the architecture decisions so the implementation PRs that follow can be reviewed on their diff, not on whether the right tool was chosen.
2. The next implementation work (wire-format crate, auth middleware, structlog/Prom/OTel scaffolding) takes multiple days each; without an RFC merged first, parallel work would diverge.
3. Closing-rationale visibility for the cleanup-sprint paper trail — anyone landing later can find the *why* without scrolling chat logs.

No code change in this PR. Pure docs.

## Test plan

- [ ] CI green (only docs change; \`docs.yml\` mkdocs build should regenerate cleanly).