### PR TITLE
ci(gitleaks): config with allowlist for mike-published site slots

### DIFF
--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -84,6 +84,7 @@ jobs:
         run: |
           gitleaks detect \
             --source . \
+            --config .gitleaks.toml \
             --no-banner \
             --redact \
             --verbose \

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,41 @@
+# gitleaks configuration for zakuro-ai/zakuro.
+#
+# Inherits the default ruleset (~140 secret-detection patterns) and adds
+# repo-specific allowlists for known false positives.
+#
+# Why this file exists:
+#   - mkdocs + mike publish a static site to a `dev/` slot on `gh-pages`.
+#     The site includes a flattened search_index.json that contains every
+#     code block from every doc page — including the CLI doc's `curl -s
+#     http://...` examples. The default gitleaks `curl-auth-user` rule
+#     matches on short-flag curl patterns and treats this as a leak,
+#     even though there's no actual credential (it's a `-s` flag, the
+#     rule's regex is over-eager around `curl -[a-z] http`).
+#   - Local mkdocs builds (`./site/`), uv venvs (`./.docvenv/`), and the
+#     build wheel staging (`./dist/`) can all contain similar derived
+#     content. They never carry real secrets — only what's already
+#     committed under `docs/`.
+#
+# When in doubt, prefer fixing the source content over silencing the
+# scanner. The path allowlist is for built/generated artefacts only.
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Built / generated artefacts and known-safe doc files"
+
+paths = [
+    '''^dev/.*''',               # mike-published `dev` site slot (gh-pages)
+    '''^[0-9]+\.[0-9]+/.*''',    # mike-published versioned site slots (gh-pages)
+    '''^latest/.*''',            # mike `latest` alias (gh-pages)
+    '''^site/.*''',              # local mkdocs build output
+    '''^\.docvenv/.*''',         # local docs venv
+    '''^dist/.*''',              # local wheel build output
+    '''^docs/.*\.json$''',       # any JSON embedded in docs/ (search indices, fixtures)
+    '''^secrets/UNENCRYPTED-TEST\.sops\.yaml$''',  # synthetic CI test fixture for the sops-encryption-check job
+]
+
+# When a finding lands in a file outside the allowlist above, fail the
+# job. We intentionally do NOT relax curl-auth-user globally; only the
+# built-site paths are excused.


### PR DESCRIPTION
Closes the gitleaks failure on #163. The \`curl-auth-user\` rule matched on \`curl -s http://...\` snippets in \`dev/search/search_index.json\` — the mike-generated search index on the \`gh-pages\` branch's \`dev/\` slot, embedding the CLI doc's example commands as plain text. No actual credential; the rule's short-flag heuristic is over-eager around \`curl -[a-z] http\`.

Adds \`.gitleaks.toml\` that:

- inherits the default ruleset (\`useDefault = true\`),
- allowlists a curated set of build/generated paths only:

| Path | Why |
|---|---|
| \`dev/.*\`, \`X.Y/.*\`, \`latest/.*\` | mike-published site slots on gh-pages |
| \`site/.*\` | local mkdocs build output |
| \`.docvenv/.*\` | local docs venv |
| \`dist/.*\` | local wheel build output |
| \`docs/.*\\.json\` | JSON embedded under docs/ (search indices, fixtures) |
| \`secrets/UNENCRYPTED-TEST.sops.yaml\` | the synthetic CI fixture for the sops-encryption-check job |

Strict-mode behaviour is preserved on every other path. The \`gitleaks\` job is wired with \`--config .gitleaks.toml\`.

Local verification: \`gitleaks detect --config .gitleaks.toml\` returns \`no leaks found\` against the current tree.

After this lands, #163 (RFC 0008 mesh gossip) needs to be rebased once and its gitleaks job will pass.