### PR TITLE
chore(docs): redirect project board links from #4 (closed) to #6 (open)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 **Zakuro is a context-aware distributed-ML runtime.** You decorate a Python function, declare a pool of workers, and the framework routes each call to the worker with the lowest expected time-to-serve — learning from every dispatch, reacting to node failures and performance drift, and never making training wait on things that can be decoupled.
 
-Product vision, engineering plan, and measured benchmark numbers live in the runtime tracking board at **[github.com/orgs/zakuro-ai/projects/4](https://github.com/orgs/zakuro-ai/projects/4)**. Each phase from the legacy `PLAN.md` is now an issue in this repo (#168–#177); the legacy `PRD.md` content is the project README. Cross-cutting enterprise hardening lives separately in [project #3](https://github.com/orgs/zakuro-ai/projects/3).
+Product vision, engineering plan, and measured benchmark numbers live in the runtime tracking board at **[github.com/orgs/zakuro-ai/projects/6](https://github.com/orgs/zakuro-ai/projects/6)**. Each phase from the legacy `PLAN.md` is now an issue in this repo (#168–#177); the legacy `PRD.md` content is the project README. Cross-cutting enterprise hardening lives separately in [project #3](https://github.com/orgs/zakuro-ai/projects/3).
 
 ## Quick start
 
@@ -159,7 +159,7 @@ All numbers come from real subprocess workers running on the Mac (see `scripts/b
 | **Drift detection** | Injected 250 ms/call slowdown ⇒ 95 % traffic diversion at **t + 0.48 s**. Recovery via softmax + health-probe latencies. |
 | **QUIC retry** | In-flight request during worker SIGKILL surfaces `ConnectionError` in **5 s** (vs aioquic's 30–60 s default). |
 
-Full numbers in the [runtime tracking board's "Measured results" section](https://github.com/orgs/zakuro-ai/projects/4) (formerly `PLAN.md`).
+Full numbers in the [runtime tracking board's "Measured results" section](https://github.com/orgs/zakuro-ai/projects/6) (formerly `PLAN.md`).
 
 ## Notebooks
 
@@ -192,7 +192,7 @@ uv run python scripts/bench_all.py --log /tmp/zakuro-bench.json
 
 ## Docs
 
-- **[Runtime tracking board](https://github.com/orgs/zakuro-ai/projects/4)** — product vision, phase status, measured benchmark numbers (formerly `PRD.md` + `PLAN.md`)
+- **[Runtime tracking board](https://github.com/orgs/zakuro-ai/projects/6)** — product vision, phase status, measured benchmark numbers (formerly `PRD.md` + `PLAN.md`)
 - **[Enterprise hardening board](https://github.com/orgs/zakuro-ai/projects/3)** — security, reliability, supply-chain, deployment
 - [`docs/STABILITY.md`](docs/STABILITY.md) — public-API contract: stable surface, semver, deprecation policy, 1.0 LTS window
 - [`docs/getting-started.md`](docs/getting-started.md) — end-to-end guide, "laptop-only" and "networked" paths

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -327,7 +327,7 @@ You're on an old zakuro (< 0.2.3). Upgrade — the current version sets `idle_ti
 
 ## Next steps
 
-- **[Runtime tracking board](https://github.com/orgs/zakuro-ai/projects/4)** — product vision, phase status, every shipped feature with the measured number next to it (formerly `PRD.md` + `PLAN.md`).
+- **[Runtime tracking board](https://github.com/orgs/zakuro-ai/projects/6)** — product vision, phase status, every shipped feature with the measured number next to it (formerly `PRD.md` + `PLAN.md`).
 - [`docs/cli.md`](cli.md) — full `zakuro-worker` CLI reference.
 - [`docs/PROTOCOL.md`](PROTOCOL.md) — QUIC wire protocol, in case you want to write a binding in another language.
 - Notebooks in the repo — `notebooks/mesh_adaptation_tour.ipynb`, `notebooks/quic_resilience.ipynb`, and `notebooks/standalone_mode.ipynb` are all executable end-to-end.

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 A context-aware distributed-ML runtime. Decorate a Python function, declare a pool of workers, and the framework routes each call to the worker with the lowest expected time-to-serve — learning from every dispatch, reacting to node failures and performance drift, and never making training wait on things that can be decoupled.
 
-For the long-form pitch, phase status, and measured engineering numbers, see the [runtime tracking board](https://github.com/orgs/zakuro-ai/projects/4) (formerly the in-tree `PRD.md` + `PLAN.md`, migrated to the GitHub Project so the source of truth lives next to the issues).
+For the long-form pitch, phase status, and measured engineering numbers, see the [runtime tracking board](https://github.com/orgs/zakuro-ai/projects/6) (formerly the in-tree `PRD.md` + `PLAN.md`, migrated to the GitHub Project so the source of truth lives next to the issues).
 
 ## Get going
 

--- a/docs/lxc-reproduction.md
+++ b/docs/lxc-reproduction.md
@@ -1,6 +1,6 @@
 # Reproducing Zakuro's benchmarks on an LXC GPU rig
 
-Step-by-step walk-through for spinning up two LXC containers on a host that has `lxd` + `nvidia-container-toolkit` installed (Ubuntu 22.04+), installing Zakuro + Sakura, and reproducing every benchmark headline from the [runtime tracking board](https://github.com/orgs/zakuro-ai/projects/4) (formerly `PLAN.md`) **from a vanilla image**.
+Step-by-step walk-through for spinning up two LXC containers on a host that has `lxd` + `nvidia-container-toolkit` installed (Ubuntu 22.04+), installing Zakuro + Sakura, and reproducing every benchmark headline from the [runtime tracking board](https://github.com/orgs/zakuro-ai/projects/6) (formerly `PLAN.md`) **from a vanilla image**.
 
 All numbers shown in the "Measured result" column below are the actual values observed when I ran this guide against a Threadripper x399 host with two GPUs. Your numbers will vary with CPU / GPU / network, but the ordering between configurations and the detection latencies should match within a factor of ~2.
 

--- a/docs/rfcs/0003-observability-stack.md
+++ b/docs/rfcs/0003-observability-stack.md
@@ -134,7 +134,7 @@ One source of truth → no drift between log tags, metric labels, span attribute
 |---|---|
 | OTel-only (logs + metrics + traces over OTLP) | Single pipeline is elegant but the OTel logs SDK is the least mature of the three; structlog is much more battle-tested for JSON log emission. Re-evaluate in 12 months. |
 | Sentry for tracing too | Sentry's trace coverage is excellent for errors-with-context but its metric story is thin (no histograms with native buckets). And we'd pay Sentry SaaS rates for every span. |
-| Defer to first customer | Was an option on the questionnaire. Rejected — the SLOs in [#127](https://github.com/zakuro-ai/zakuro/issues/127) require *some* metric backend to exist before they can be defined, and the headline numbers in the [runtime tracking board](https://github.com/orgs/zakuro-ai/projects/4) are currently in-memory + ephemeral. |
+| Defer to first customer | Was an option on the questionnaire. Rejected — the SLOs in [#127](https://github.com/zakuro-ai/zakuro/issues/127) require *some* metric backend to exist before they can be defined, and the headline numbers in the [runtime tracking board](https://github.com/orgs/zakuro-ai/projects/6) are currently in-memory + ephemeral. |
 | ELK stack | Heavyweight on the indexing tier. We'd need to maintain Elasticsearch. Out of scope while a single team is shipping. |
 
 ## Migration / rollout

--- a/docs/rfcs/0004-deployment-p2p-quic.md
+++ b/docs/rfcs/0004-deployment-p2p-quic.md
@@ -83,7 +83,7 @@ slsa-verifier verify-artifact \
 
 | Option | Why rejected |
 |---|---|
-| Keep Kubernetes as the recommended path | Imposes operator burden (cluster, kubelet, control plane) on every Zakuro consumer. Goes against the "decorate a function, ship it" pitch in the [runtime tracking board's product pitch](https://github.com/orgs/zakuro-ai/projects/4). |
+| Keep Kubernetes as the recommended path | Imposes operator burden (cluster, kubelet, control plane) on every Zakuro consumer. Goes against the "decorate a function, ship it" pitch in the [runtime tracking board's product pitch](https://github.com/orgs/zakuro-ai/projects/6). |
 | Standalone binary + manual peer config (no gossip) | Works for ≤3 nodes; collapses at 10+. The mesh value-prop assumes auto-discovery. |
 | Nomad / HashiCorp stack | Lighter than k8s, but still external orchestrator. The P2P story is more compelling commercially (operates anywhere, no cluster required). |
 | libp2p as the transport | Mature P2P stack but pulls in DHT, NAT-traversal, content-routing layers we don't need yet. QUIC + custom gossip stays leaner. Re-evaluate if NAT-traversal becomes a customer ask. |


### PR DESCRIPTION
## Summary

- PR #178 migrated the PRD.md + PLAN.md content to org Project #4, but that project had been closed on 2026-04-19 so the work landed in a dormant board.
- Created a fresh open Project #6 ("Zakuro runtime") with the same README content (7.4 KB) and re-attached all 10 plan-projected issues (#168–#177).
- This PR fixes the in-repo links so README.md, docs/index.md, docs/getting-started.md, docs/lxc-reproduction.md, and RFCs 0003 + 0004 all point at the active project, not the archived one.

The closed Project #4 keeps its README + items as an archived snapshot; nothing destructive happens to it.

## Test plan

- [x] `mkdocs build --strict` passes locally (no broken-link regressions)
- [x] `grep -r "projects/4" docs README.md` returns zero hits
- [x] Project #6 has all 10 items (#168–#177) attached