### PR TITLE
docs: add SECURITY.md, CONTRIBUTING.md, CODE_OF_CONDUCT.md (#112)

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,19 @@
+# Code of Conduct
+
+This project adopts the **[Contributor Covenant v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/)** as its code of conduct, without modification.
+
+The full text is available at the link above, and a local copy ships with the upstream Covenant project at <https://github.com/EthicalSource/contributor_covenant>.
+
+## Reporting
+
+Reports of conduct issues go to **conduct@zakuro.ai**. Reports are treated as confidential. We acknowledge every report within 2 business days and respond with a triage decision within 10 business days.
+
+For project-security issues (vulnerabilities, supply-chain concerns) see [`SECURITY.md`](SECURITY.md) instead — the channel is different.
+
+## Scope
+
+The Covenant applies in all project spaces — GitHub issues and PRs, Discussions, Slack/Discord if/when those exist, the `dev@zakuro.ai` mailing list, and any in-person or virtual events organized in the project's name.
+
+## Attribution
+
+Code of Conduct text © Contributor Covenant authors, licensed CC BY 4.0. See the [Covenant FAQ](https://www.contributor-covenant.org/faq/).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,89 @@
+# Contributing to Zakuro
+
+Thanks for your interest. This document covers everything you need to send a patch that has a good chance of being merged quickly.
+
+## Code of Conduct
+
+Participation in this project is governed by the [Contributor Covenant](CODE_OF_CONDUCT.md). By contributing you agree to abide by it.
+
+## Quick links
+
+- **Bugs and feature requests** → [GitHub Issues](https://github.com/zakuro-ai/zakuro/issues)
+- **Security issues** → see [`SECURITY.md`](SECURITY.md) (do **not** file a public issue)
+- **Architectural decisions** → [`docs/rfcs/`](docs/rfcs/)
+- **Active roadmap** → [Runtime tracking board](https://github.com/orgs/zakuro-ai/projects/6)
+
+## Development setup
+
+You'll need Python 3.10+ and [`uv`](https://github.com/astral-sh/uv).
+
+```bash
+git clone git@github.com:zakuro-ai/zakuro.git
+cd zakuro
+uv sync --extra all                  # full dev install (worker + processors + dev tools)
+uv run pre-commit install            # ruff + mypy + gitleaks on every commit
+uv run pytest                        # 90+ tests, ~30 s on a laptop
+```
+
+For the Rust workspace (`crates/zakuro-wire`) you'll also need a stable Rust toolchain. `cargo test --workspace` from the repo root.
+
+The full dev loop runs in Docker too:
+
+```bash
+task ci-local                        # mirrors what GitHub Actions runs
+```
+
+## Branch + commit conventions
+
+- Branch names: `kind/short-slug-NNN` where `NNN` is the issue number when applicable.
+  - `feat/`, `fix/`, `chore/`, `docs/`, `refactor/`, `test/`, `ci/`, `perf/`, `security/`.
+- Commit messages: [Conventional Commits](https://www.conventionalcommits.org/).
+  - `fix(quic): close connection cleanly on worker shutdown (#142)`
+  - `feat(adaptive): add price-aware routing (#173)`
+- **Do not add `Co-Authored-By` trailers to commits or PR bodies.** Squash-merge rewrites authorship on the merge commit; trailers cause duplicate credit.
+- Sign your commits (`git commit -S`) when you can — not required, but appreciated.
+
+## Pull-request checklist
+
+Before you click "Create PR":
+
+- [ ] `task ci-local` passes (ruff, mypy, pytest, cargo test).
+- [ ] New code has tests in `tests/` (Python) or `crates/*/tests/` (Rust).
+- [ ] Public-API changes update [`docs/STABILITY.md`](docs/STABILITY.md) and the typed surface in `zakuro/public.py`.
+- [ ] Wire-format / broker-contract changes are paired with a `zakuro-ai/zc` PR — these two repos move together via the `zakuro-wire` crate (see [RFC 0001](docs/rfcs/0001-wire-format-postcard.md)).
+- [ ] Dockerfile / image / SBOM changes go in [`zakuro-ai/zakuro-image`](https://github.com/zakuro-ai/zakuro-image), not here.
+- [ ] PR title follows Conventional Commits and references the issue (`feat(x): … (#N)`).
+- [ ] PR body has a "Summary" + "Test plan" section. The PR template enforces this.
+
+## What gets reviewed
+
+- **Correctness** before style. Reviewer questions on logic land first; reviewer nits on naming land later.
+- **Public-API stability.** Anything reachable from `zakuro.public` is subject to the SemVer policy in `docs/STABILITY.md` — breaking changes need a deprecation cycle.
+- **Cross-repo coherence.** If your change moves the wire format or the broker contract, the reviewer will check for a paired zc PR. If it touches the container image, they'll check for a paired zakuro-image PR.
+- **Test coverage.** New code without tests is a request-changes; we can help you write them if the framework feels unfamiliar.
+- **Observability and security.** New endpoints need auth scopes (RFC 0002), new metrics need cardinality budgets (RFC 0003), new dependencies need an SBOM-friendly licence.
+
+We aim for a first review within **2 business days**. If a PR sits idle longer than that, ping `@zakuro-ai/maintainers` on the PR — it's not impolite, it's expected.
+
+## Local testing tips
+
+- `pytest -x -k <substring>` is the fastest way to iterate on a single failure.
+- `pytest -m integration` runs the docker-compose smoke lane locally (needs Docker).
+- For QUIC-related changes, `pytest -m quic --tb=short` runs only those tests.
+- Set `ZAKURO_LOG_LEVEL=DEBUG` for structured-log verbosity during a test run.
+
+## RFCs
+
+If you're proposing a non-trivial change — new public API, new on-wire field, new dependency, new deployment shape — open a short RFC under `docs/rfcs/`. Use the existing RFCs as a template. RFCs land via PR, like code.
+
+## Releasing
+
+Releases are automated via `release-please`. The `chore(release): vX.Y.Z [skip release]` commits are bot output — don't write them by hand.
+
+## Questions
+
+- Open a GitHub Discussion for design questions or longer-form conversations.
+- Use issues for bugs and concrete feature asks.
+- For private questions email `dev@zakuro.ai`.
+
+We're happy you're here. Send the patch.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,65 @@
+# Security policy
+
+Thank you for helping keep Zakuro and its users safe.
+
+## Supported versions
+
+Zakuro is pre-1.0. Only the **current minor release on `master`** receives security fixes. Once 1.0 ships, the project will adopt a 24-month LTS window for the latest minor (see [`docs/STABILITY.md`](docs/STABILITY.md)).
+
+| Version | Supported |
+|---|---|
+| `master` (latest minor) | ✅ |
+| Older 0.x | ❌ — please upgrade |
+
+## Reporting a vulnerability
+
+**Do not file a public issue.** Email **security@zakuro.ai** with the details listed below. We reply within **2 business days** to acknowledge the report and within **10 business days** with a triage classification (accept / mitigate / decline) and a tentative fix window.
+
+For especially sensitive reports, request our GPG public key in your initial message and we will send it before you transmit any proof-of-concept.
+
+Include in your report:
+
+- A description of the issue and the attacker capability it gives.
+- A minimal reproduction (command, code snippet, or HTTP request).
+- The affected version (`zakuro.__version__`), Python version, and platform.
+- Whether the issue is already public anywhere (mailing list, blog, CVE database).
+- Optional: a suggested fix or mitigation.
+
+## What counts as a vulnerability
+
+In scope:
+
+- Remote code execution, sandbox escape, or privilege escalation in the worker or broker.
+- Authentication or authorization bypass — anything that lets an unauthenticated caller invoke a worker, or lets one tenant act as another.
+- Cryptographic weaknesses (TLS / JWT / signing) in the published artifacts.
+- Supply-chain integrity issues — tampered wheels, tampered images, signature-verification bypasses against the published cosign/SLSA attestations.
+- Sensitive-data exposure (credentials, tokens, request bodies) in logs, errors, or telemetry.
+- DoS amplification specific to Zakuro (a worker can be made to consume unbounded resources from a single small request).
+
+Out of scope:
+
+- Vulnerabilities in dependencies that have a public CVE and a published fix — please file a regular issue or open a PR to bump the pin.
+- Issues that require pre-existing root / admin on the worker host.
+- Social-engineering or physical-access attacks.
+- DoS against `zakuro-ai.com` infrastructure — report those directly to operations.
+- Findings against a fork or a release older than the current minor.
+
+## Disclosure policy
+
+We follow **coordinated disclosure**.
+
+1. We acknowledge the report.
+2. We confirm or decline the vulnerability and agree a fix window with you. Typical windows: 30 days (Critical), 60 days (High), 90 days (Moderate).
+3. We prepare a patched release, a CVE (where applicable), and a credit line.
+4. We coordinate a disclosure date with you. Default is **30 days after a fix ships**, or sooner if the issue is already public.
+5. We publish a GitHub Security Advisory and add the CVE to [`docs/security/advisories.md`](docs/security/advisories.md).
+
+If we miss our triage SLA you are free to disclose publicly without further notice; in that case please give us a heads-up email so we can prepare.
+
+## Verifying releases
+
+Every wheel and container image is signed (Cosign keyless) and accompanied by a SLSA L3 provenance attestation. The verification one-liners live at [`docs/security/verifying-releases.md`](docs/security/verifying-releases.md).
+
+## Hall of fame
+
+Security researchers who have responsibly disclosed issues to us are credited in [`docs/security/hall-of-fame.md`](docs/security/hall-of-fame.md) (with their permission). We do not run a paid bug-bounty program at this time.


### PR DESCRIPTION
## Summary

Closes #112.

- **SECURITY.md** — vulnerability-report process (security@zakuro.ai), triage SLA, in/out-of-scope list, coordinated-disclosure policy.
- **CONTRIBUTING.md** — dev setup, Conventional Commits, PR checklist that calls out cross-repo coherence (paired zc PR for wire-format changes; image work in zakuro-image).
- **CODE_OF_CONDUCT.md** — adopts Contributor Covenant v2.1 by reference; conduct@zakuro.ai for reports.

No code changes; pure docs.

## Test plan

- [x] `mkdocs build --strict` still passes (no broken links to new files yet).
- [x] All three files render cleanly on GitHub.
- [x] References to `docs/security/verifying-releases.md` and `docs/STABILITY.md` point at existing files.