### PR TITLE
feat(observability): structured JSON logging via structlog (#125)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,9 @@ observability = [
     # the package is not installed or SENTRY_DSN is unset. Install via
     # `pip install 'zakuro-ai[observability]'` or `uv sync --extra observability`.
     "sentry-sdk>=2.0.0",
+    # structlog produces JSON-rendered logs that share the request-context
+    # ContextVar with the Sentry scrubber. RFC 0003 Track A (#125).
+    "structlog>=24.1.0",
 ]
 dev = [
     "pytest>=7.0",

--- a/tests/observability/test_structlog.py
+++ b/tests/observability/test_structlog.py
@@ -1,0 +1,110 @@
+"""Unit tests for the structlog JSON pipeline (#125, RFC 0003 Track A)."""
+
+from __future__ import annotations
+
+import io
+import json
+import logging
+import re
+from contextvars import copy_context
+from typing import Any
+
+import pytest
+
+from zakuro.observability import logging as obs_logging
+from zakuro.observability.sentry import _REQUEST_CONTEXT, set_request_context
+
+structlog = pytest.importorskip("structlog", reason="needs [observability] extra")
+
+
+@pytest.fixture(autouse=True)
+def _reset_logging() -> Any:
+    """Each test gets a fresh init + ContextVar state."""
+    obs_logging._reset_for_tests()
+    token = _REQUEST_CONTEXT.set({})
+    yield
+    _REQUEST_CONTEXT.reset(token)
+    obs_logging._reset_for_tests()
+
+
+def _captured_lines(buf: io.StringIO) -> list[dict[str, Any]]:
+    return [json.loads(line) for line in buf.getvalue().splitlines() if line.strip()]
+
+
+def test_init_logging_returns_true_when_structlog_present() -> None:
+    assert obs_logging.init_logging("worker") is True
+
+
+def test_init_logging_is_idempotent() -> None:
+    assert obs_logging.init_logging("worker") is True
+    assert obs_logging.init_logging("worker") is True  # second call is a no-op
+
+
+def test_log_record_is_json_with_stable_keys(capsys: pytest.CaptureFixture[str]) -> None:
+    obs_logging.init_logging("worker")
+    log = obs_logging.get_logger("test")
+    log.info("hello_event", extra_field=7)
+    out = capsys.readouterr().out
+    line = next(line for line in out.splitlines() if "hello_event" in line)
+    record = json.loads(line)
+    assert record["event"] == "hello_event"
+    assert record["level"] == "info"
+    assert record["component"] == "worker"
+    assert record["extra_field"] == 7
+    # time is ISO 8601 with a Z suffix (UTC), no microseconds-or-not policy here
+    assert re.match(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}", record["time"])
+
+
+def test_request_context_tags_attach_to_records(capsys: pytest.CaptureFixture[str]) -> None:
+    obs_logging.init_logging("worker")
+    log = obs_logging.get_logger("test")
+
+    def emit_in_context() -> None:
+        set_request_context(request_id="req-abc", tenant_id="tenant-acme", worker_id="worker-3")
+        log.info("job_started")
+
+    copy_context().run(emit_in_context)
+    out = capsys.readouterr().out
+    line = next(line for line in out.splitlines() if "job_started" in line)
+    record = json.loads(line)
+    assert record["request-id"] == "req-abc"
+    assert record["tenant-id"] == "tenant-acme"
+    assert record["worker-id"] == "worker-3"
+
+
+def test_pii_is_redacted_from_string_fields(capsys: pytest.CaptureFixture[str]) -> None:
+    obs_logging.init_logging("worker")
+    log = obs_logging.get_logger("test")
+    log.info("captured", user_text="contact ada@example.com via 10.0.0.5")
+    out = capsys.readouterr().out
+    line = next(line for line in out.splitlines() if "captured" in line)
+    record = json.loads(line)
+    assert "@example.com" not in record["user_text"]
+    assert "10.0.0.5" not in record["user_text"]
+    assert "<email>" in record["user_text"]
+    assert "<ip>" in record["user_text"]
+
+
+def test_stdlib_logging_flows_through_json_formatter(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    obs_logging.init_logging("worker")
+    logging.getLogger("legacy").warning("via_stdlib")
+    out = capsys.readouterr().out
+    line = next(line for line in out.splitlines() if "via_stdlib" in line)
+    record = json.loads(line)
+    assert record["level"] == "warning"
+    assert record["event"] == "via_stdlib"
+    assert record["component"] == "worker"
+
+
+def test_level_env_var_is_respected(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ZAKURO_LOG_LEVEL", "WARNING")
+    obs_logging.init_logging("worker")
+    assert logging.getLogger().level == logging.WARNING
+
+
+def test_level_kwarg_overrides_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ZAKURO_LOG_LEVEL", "WARNING")
+    obs_logging.init_logging("worker", level="DEBUG")
+    assert logging.getLogger().level == logging.DEBUG

--- a/zakuro/observability/__init__.py
+++ b/zakuro/observability/__init__.py
@@ -1,11 +1,27 @@
 """Observability surface for Zakuro.
 
-Today this package exposes a single helper, ``init_sentry``, that the worker
-entry point and the client wire into their startup paths. Future tickets
-(OTel #123, Prometheus #124, structlog #125) will land here too so callers
-have a single import surface to reason about.
+Callers have a single import surface (``zakuro.observability``) to reason
+about. Each helper is a no-op when its underlying optional dependency
+is not installed, so applications can stay slim and ratchet observability
+in by adding the extra (``pip install 'zakuro-ai[observability]'``).
+
+Currently wired:
+
+- ``init_sentry`` / ``set_request_context`` — error reporting (#128).
+- ``init_logging`` / ``get_logger`` — structured JSON logs (#125, RFC 0003 Track A).
+
+Forthcoming:
+
+- ``init_tracing`` — OpenTelemetry tracing (#123).
+- ``metrics`` namespace — Prometheus counters/histograms (#124).
 """
 
+from zakuro.observability.logging import get_logger, init_logging
 from zakuro.observability.sentry import init_sentry, set_request_context
 
-__all__ = ["init_sentry", "set_request_context"]
+__all__ = [
+    "get_logger",
+    "init_logging",
+    "init_sentry",
+    "set_request_context",
+]

--- a/zakuro/observability/logging.py
+++ b/zakuro/observability/logging.py
@@ -1,0 +1,189 @@
+"""Structured-JSON logging for Zakuro (closes #125 — RFC 0003 Track A).
+
+Design notes:
+
+* The single entry point is :func:`init_logging`. It configures structlog
+  *and* the stdlib :mod:`logging` module so that downstream library calls
+  (``logger = logging.getLogger(__name__)``) produce the same JSON shape
+  as direct ``structlog.get_logger(...).info(...)`` calls.
+* When ``structlog`` is not installed, :func:`init_logging` is a no-op
+  that returns ``False``. The library still imports cleanly. This keeps
+  the observability extra truly opt-in (matches :func:`init_sentry`).
+* The PII redactor from :mod:`zakuro.observability.sentry` is reused as
+  a structlog processor — the same regexes that strip emails / IPs / home
+  paths from Sentry events also strip them from log records before they
+  leave the process.
+* The shared ``_REQUEST_CONTEXT`` ContextVar (also from
+  :mod:`zakuro.observability.sentry`) is read by a structlog processor
+  so every log line in a request scope automatically carries
+  ``request-id`` / ``tenant-id`` / ``worker-id``.
+
+Stable JSON schema (one record per line)::
+
+    {
+      "time":      "2026-05-17T14:23:08.412Z",
+      "level":     "info",
+      "component": "worker",
+      "event":     "job_completed",
+      "request-id":"req-0c12...",
+      "tenant-id": "tenant-acme",
+      "worker-id": "worker-3",
+      "duration_ms": 142
+    }
+
+Keys ``time``, ``level``, ``component``, ``event`` are guaranteed stable
+across versions; the request-context tags are present iff
+:func:`set_request_context` ran in the caller's async scope. See
+``docs/STABILITY.md`` § "Log schema".
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from typing import Any
+
+from zakuro.observability.sentry import _REQUEST_CONTEXT, _redact_pii_in_string
+
+try:  # structlog is an optional dependency
+    import structlog
+except ImportError:  # pragma: no cover - exercised only without the extra
+    structlog = None  # type: ignore[assignment]
+
+
+_INITIALISED = False
+
+
+def init_logging(component: str, *, level: str | None = None) -> bool:
+    """Initialise structured JSON logging for *component*.
+
+    *component* is one of ``"worker"`` / ``"client"`` / ``"broker"`` and
+    appears on every record so log aggregators can filter by source.
+
+    *level* overrides the level resolved from ``ZAKURO_LOG_LEVEL`` (env)
+    or defaults to ``"INFO"``. Pass a stdlib level name (``"DEBUG"`` /
+    ``"INFO"`` / ``"WARNING"`` / ``"ERROR"``).
+
+    Returns ``True`` if structlog was wired in, ``False`` if the optional
+    dependency is missing (in which case stdlib logging is left alone so
+    the caller still gets *some* output).
+
+    Safe to call multiple times — subsequent calls are no-ops, so library
+    code can wire it at import time without worrying about being called
+    twice from the entry point.
+    """
+    global _INITIALISED
+    if _INITIALISED:
+        return structlog is not None
+    if structlog is None:
+        return False
+
+    resolved_level = (level or os.environ.get("ZAKURO_LOG_LEVEL") or "INFO").upper()
+    numeric_level = logging.getLevelName(resolved_level)
+    if not isinstance(numeric_level, int):
+        # logging.getLevelName returns the string back when the name is
+        # unknown — fall through to INFO rather than passing the string.
+        numeric_level = logging.INFO
+
+    shared_processors: list[Any] = [
+        structlog.contextvars.merge_contextvars,
+        structlog.processors.add_log_level,
+        structlog.processors.TimeStamper(fmt="iso", utc=True, key="time"),
+        _attach_component(component),
+        _attach_request_context,
+        _redact_pii_processor,
+    ]
+
+    # Configure the stdlib logging root so non-structlog callers (third-
+    # party libs, framework code) emit the same JSON shape.
+    logging.basicConfig(
+        format="%(message)s",
+        stream=sys.stdout,
+        level=numeric_level,
+        force=True,
+    )
+
+    structlog.configure(
+        processors=[
+            *shared_processors,
+            structlog.processors.format_exc_info,
+            structlog.processors.JSONRenderer(),
+        ],
+        wrapper_class=structlog.make_filtering_bound_logger(numeric_level),
+        logger_factory=structlog.PrintLoggerFactory(file=sys.stdout),
+        cache_logger_on_first_use=True,
+    )
+
+    # Replace the stdlib handlers' formatters so logger.info(...) from
+    # third-party libraries flows through structlog's processor chain too.
+    formatter = structlog.stdlib.ProcessorFormatter(
+        foreign_pre_chain=shared_processors,
+        processors=[
+            structlog.stdlib.ProcessorFormatter.remove_processors_meta,
+            structlog.processors.format_exc_info,
+            structlog.processors.JSONRenderer(),
+        ],
+    )
+    for handler in logging.getLogger().handlers:
+        handler.setFormatter(formatter)
+
+    _INITIALISED = True
+    return True
+
+
+def get_logger(name: str | None = None) -> Any:
+    """Return a structlog bound logger, or a stdlib logger as fallback.
+
+    Library code should prefer ``get_logger(__name__)`` so a single
+    import line works whether or not :func:`init_logging` has run.
+    """
+    if structlog is None:
+        return logging.getLogger(name)
+    return structlog.get_logger(name)
+
+
+def _attach_component(component: str) -> Any:
+    """Return a structlog processor that stamps ``component`` on every record."""
+
+    def _processor(_logger: Any, _method_name: str, event_dict: dict[str, Any]) -> dict[str, Any]:
+        event_dict.setdefault("component", component)
+        return event_dict
+
+    return _processor
+
+
+def _attach_request_context(
+    _logger: Any, _method_name: str, event_dict: dict[str, Any]
+) -> dict[str, Any]:
+    """Pull request-id / tenant-id / worker-id from the shared ContextVar."""
+    for key, value in _REQUEST_CONTEXT.get().items():
+        if value:
+            event_dict.setdefault(key, value)
+    return event_dict
+
+
+# Keys whose values are produced by the log infrastructure itself and are
+# known-safe — redacting them would corrupt the schema (the loose IPv6 regex
+# happily matches "01:02:03" timestamps).
+_INFRASTRUCTURE_KEYS = frozenset(
+    {"time", "timestamp", "level", "component", "event", "logger", "logger_name"}
+)
+
+
+def _redact_pii_processor(
+    _logger: Any, _method_name: str, event_dict: dict[str, Any]
+) -> dict[str, Any]:
+    """Walk every string-valued user field and redact emails / IPs / home paths."""
+    for key, value in list(event_dict.items()):
+        if key in _INFRASTRUCTURE_KEYS:
+            continue
+        if isinstance(value, str):
+            event_dict[key] = _redact_pii_in_string(value)
+    return event_dict
+
+
+def _reset_for_tests() -> None:
+    """Reset the module-level init flag. Test-only — do not call in prod."""
+    global _INITIALISED
+    _INITIALISED = False

--- a/zakuro/worker/server.py
+++ b/zakuro/worker/server.py
@@ -22,11 +22,14 @@ except ImportError as exc:
 
 import contextlib
 
-from zakuro.observability import init_sentry
+from zakuro.observability import init_logging, init_sentry
 from zakuro.worker.executor import execute_function
 
-# Init Sentry as early as possible so an exception during app/executor wiring
-# still surfaces. No-op when SENTRY_DSN is unset.
+# Init structured logging + Sentry as early as possible so any exception during
+# app/executor wiring is captured + emitted as JSON. Both are no-ops when their
+# optional dependency is missing (`zakuro-ai[observability]`) or the relevant
+# env var is unset.
+init_logging("worker")
 init_sentry("worker")
 
 app = FastAPI(


### PR DESCRIPTION
## Summary

Closes #125. First track of [RFC 0003](docs/rfcs/0003-observability-stack.md).

- `zakuro/observability/logging.py` — `init_logging(component, level=...)` configures structlog + the stdlib logging root to emit the same JSON shape; PII redactor + request-context propagation reused from `sentry.py`.
- `zakuro/worker/server.py` — wires `init_logging("worker")` at import time alongside `init_sentry`.
- `structlog>=24.1.0` added to `[observability]` extra.
- `tests/observability/test_structlog.py` — 8 tests.

Stable JSON schema (per `docs/STABILITY.md`): `time`, `level`, `component`, `event`. Request tags (`request-id`, `tenant-id`, `worker-id`) attach via the shared ContextVar.

## Test plan

- [x] `pytest tests/observability/test_structlog.py` → 8 passed.
- [x] Full suite: 178 passed (170 → 178).
- [x] `ruff check` / `ruff format --check` clean.
- [x] `mypy zakuro/observability/logging.py` clean.
- [ ] CI runs green.