### PR TITLE
feat(observability): Prometheus /metrics endpoint + collectors (#124)

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -37,6 +37,9 @@ Python runtime dependencies
   * pyspark 4.1.1  <https://github.com/apache/spark/tree/master/python>
   * pytest-asyncio 1.3.0  <https://github.com/pytest-dev/pytest-asyncio>
 
+--- Apache-2.0 AND BSD-2-Clause (1 package(s)) ---
+  * prometheus_client 0.25.0  <https://github.com/prometheus/client_python>
+
 --- Apache-2.0 OR BSD-2-Clause (1 package(s)) ---
   * packaging 26.0  <https://github.com/pypa/packaging>
 
@@ -82,7 +85,7 @@ Python runtime dependencies
   * uvicorn 0.40.0  <https://uvicorn.dev/>
   * websockets 16.0  <https://github.com/python-websockets/websockets>
 
---- MIT (28 package(s)) ---
+--- MIT (29 package(s)) ---
   * annotated-doc 0.0.4  <https://github.com/fastapi/annotated-doc>
   * anyio 4.12.1  <https://anyio.readthedocs.io/en/stable/versionhistory.html>
   * argon2-cffi 25.1.0  <https://github.com/hynek/argon2-cffi/blob/main/CHANGELOG.md>
@@ -102,6 +105,7 @@ Python runtime dependencies
   * pre_commit 4.5.1  <https://github.com/pre-commit/pre-commit>
   * pydantic 2.12.5  <https://github.com/pydantic/pydantic>
   * pydantic_core 2.41.5  <https://github.com/pydantic/pydantic-core>
+  * PyJWT 2.12.1  <https://github.com/jpadilla/pyjwt>
   * pytest 9.0.2  <https://docs.pytest.org/en/latest/>
   * pytest-cov 7.0.0  <https://pytest-cov.readthedocs.io/en/latest/changelog.html>
   * referencing 0.37.0  <https://github.com/python-jsonschema/referencing>
@@ -121,6 +125,9 @@ Python runtime dependencies
   * PyYAML 6.0.3  <https://pyyaml.org/>
   * ruff 0.15.0  <https://docs.astral.sh/ruff>
   * watchfiles 1.1.1  <https://github.com/samuelcolvin/watchfiles>
+
+--- MIT OR Apache-2.0 (1 package(s)) ---
+  * structlog 25.5.0  <https://github.com/hynek/structlog/blob/main/CHANGELOG.md>
 
 --- Mozilla Public License 2.0 (MPL 2.0) (2 package(s)) ---
   * certifi 2026.1.4  <https://github.com/certifi/python-certifi>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,9 @@ observability = [
     # structlog produces JSON-rendered logs that share the request-context
     # ContextVar with the Sentry scrubber. RFC 0003 Track A (#125).
     "structlog>=24.1.0",
+    # Prometheus client for /metrics. RFC 0003 Track B (#124). No-op when
+    # the dep is missing.
+    "prometheus_client>=0.20.0",
 ]
 dev = [
     "pytest>=7.0",

--- a/tests/observability/test_metrics.py
+++ b/tests/observability/test_metrics.py
@@ -1,0 +1,105 @@
+"""Unit tests for the Prometheus metrics surface (#124, RFC 0003 Track B)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from zakuro.observability import metrics as obs_metrics
+
+prom = pytest.importorskip("prometheus_client", reason="needs [observability] extra")
+
+
+@pytest.fixture(autouse=True)
+def _reset_metrics() -> Any:
+    obs_metrics._reset_for_tests()
+    yield
+    obs_metrics._reset_for_tests()
+
+
+def test_init_metrics_is_idempotent_and_signals_enabled() -> None:
+    assert obs_metrics.init_metrics() is True
+    assert obs_metrics.init_metrics() is True
+    assert obs_metrics.is_enabled() is True
+
+
+def test_record_http_request_increments_counter() -> None:
+    obs_metrics.init_metrics()
+    obs_metrics.record_http_request("POST", "/execute", 200, "tenant-acme")
+    obs_metrics.record_http_request("POST", "/execute", 200, "tenant-acme")
+    obs_metrics.record_http_request("POST", "/execute", 500, "tenant-acme")
+
+    body = prom.generate_latest(prom.REGISTRY).decode()
+    assert (
+        'zakuro_http_requests_total{method="POST",path="/execute",status="200",tenant_id="tenant-acme"} 2.0'
+        in body
+    )
+    assert (
+        'zakuro_http_requests_total{method="POST",path="/execute",status="500",tenant_id="tenant-acme"} 1.0'
+        in body
+    )
+
+
+def test_observe_dispatch_latency_records_histogram_sample() -> None:
+    obs_metrics.init_metrics()
+    stop = obs_metrics.observe_dispatch_latency("worker-1", "tenant-acme")
+    stop()
+
+    body = prom.generate_latest(prom.REGISTRY).decode()
+    assert "zakuro_dispatch_latency_seconds_count" in body
+    # one sample observed → count for the labelset is 1
+    assert (
+        'zakuro_dispatch_latency_seconds_count{tenant_id="tenant-acme",worker_id="worker-1"} 1.0'
+        in body
+    )
+
+
+def test_set_worker_queue_depth_updates_gauge() -> None:
+    obs_metrics.init_metrics()
+    obs_metrics.set_worker_queue_depth("worker-1", 7)
+    body = prom.generate_latest(prom.REGISTRY).decode()
+    assert 'zakuro_worker_queue_depth{worker_id="worker-1"} 7.0' in body
+    obs_metrics.set_worker_queue_depth("worker-1", 0)
+    body = prom.generate_latest(prom.REGISTRY).decode()
+    assert 'zakuro_worker_queue_depth{worker_id="worker-1"} 0.0' in body
+
+
+def test_record_auth_failure_increments_counter() -> None:
+    obs_metrics.init_metrics()
+    obs_metrics.record_auth_failure("missing_jwt", "tenant-acme")
+    obs_metrics.record_auth_failure("missing_jwt", "tenant-acme")
+    obs_metrics.record_auth_failure("bad_scope", "tenant-acme")
+
+    body = prom.generate_latest(prom.REGISTRY).decode()
+    assert 'zakuro_auth_failure_total{reason="missing_jwt",tenant_id="tenant-acme"} 2.0' in body
+    assert 'zakuro_auth_failure_total{reason="bad_scope",tenant_id="tenant-acme"} 1.0' in body
+
+
+def test_mount_metrics_endpoint_serves_exposition() -> None:
+    pytest.importorskip("fastapi")
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    app = FastAPI()
+    obs_metrics.init_metrics()
+    obs_metrics.mount_metrics_endpoint(app)
+    obs_metrics.set_worker_queue_depth("worker-1", 3)
+
+    client = TestClient(app)
+    resp = client.get("/metrics")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/plain")
+    assert "zakuro_worker_queue_depth" in resp.text
+
+
+def test_metric_names_follow_prometheus_conventions() -> None:
+    """All declared metric names use <namespace>_<subsystem>_<name>_<unit>."""
+    for metric in (
+        obs_metrics.HTTP_REQUESTS_TOTAL,
+        obs_metrics.DISPATCH_LATENCY_SECONDS,
+        obs_metrics.WORKER_QUEUE_DEPTH,
+        obs_metrics.AUTH_FAILURE_TOTAL,
+    ):
+        name = metric._name  # noqa: SLF001 — prometheus_client exposes _name
+        assert name.startswith("zakuro_"), f"metric {name} missing zakuro_ namespace"

--- a/zakuro/observability/__init__.py
+++ b/zakuro/observability/__init__.py
@@ -9,19 +9,45 @@ Currently wired:
 
 - ``init_sentry`` / ``set_request_context`` — error reporting (#128).
 - ``init_logging`` / ``get_logger`` — structured JSON logs (#125, RFC 0003 Track A).
+- ``init_metrics`` + ``mount_metrics_endpoint`` — Prometheus (#124, RFC 0003 Track B).
 
 Forthcoming:
 
 - ``init_tracing`` — OpenTelemetry tracing (#123).
-- ``metrics`` namespace — Prometheus counters/histograms (#124).
 """
 
 from zakuro.observability.logging import get_logger, init_logging
+from zakuro.observability.metrics import (
+    AUTH_FAILURE_TOTAL,
+    DISPATCH_LATENCY_SECONDS,
+    HTTP_REQUESTS_TOTAL,
+    WORKER_QUEUE_DEPTH,
+    init_metrics,
+    mount_metrics_endpoint,
+    observe_dispatch_latency,
+    record_auth_failure,
+    record_http_request,
+    set_worker_queue_depth,
+)
+from zakuro.observability.metrics import (
+    is_enabled as metrics_enabled,
+)
 from zakuro.observability.sentry import init_sentry, set_request_context
 
 __all__ = [
+    "AUTH_FAILURE_TOTAL",
+    "DISPATCH_LATENCY_SECONDS",
+    "HTTP_REQUESTS_TOTAL",
+    "WORKER_QUEUE_DEPTH",
     "get_logger",
     "init_logging",
+    "init_metrics",
     "init_sentry",
+    "metrics_enabled",
+    "mount_metrics_endpoint",
+    "observe_dispatch_latency",
+    "record_auth_failure",
+    "record_http_request",
     "set_request_context",
+    "set_worker_queue_depth",
 ]

--- a/zakuro/observability/metrics.py
+++ b/zakuro/observability/metrics.py
@@ -1,0 +1,186 @@
+"""Prometheus metrics for Zakuro (closes #124 — RFC 0003 Track B).
+
+Design notes:
+
+* The single entry point is :func:`init_metrics`. It enables instrumentation
+  by toggling a module-level flag — the underlying collectors are imported
+  unconditionally so the metric names exist even if ``prometheus_client`` is
+  not installed (in that case the collectors are stubbed and ``init_metrics``
+  returns ``False``).
+* Naming follows
+  `Prometheus best practices <https://prometheus.io/docs/practices/naming/>`_:
+  ``<namespace>_<subsystem>_<name>_<unit>``.
+* Label cardinality is **strictly bounded**. We refuse to add labels that
+  could blow up the TSDB:
+    - ``tenant_id``  — bounded (~hundreds);
+    - ``worker_id``  — bounded (~tens);
+    - ``path`` / ``method`` — enumerated by FastAPI routes.
+* :func:`mount_metrics_endpoint` registers ``/metrics`` on a FastAPI app
+  with appropriate ``text/plain; version=0.0.4`` content-type. Auth is
+  the caller's responsibility — once RFC 0002 lands, gate it on the
+  ``metrics:read`` JWT scope.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from typing import Any
+
+try:  # prometheus_client is an optional dependency
+    from prometheus_client import (
+        CONTENT_TYPE_LATEST,
+        REGISTRY,
+        CollectorRegistry,
+        Counter,
+        Gauge,
+        Histogram,
+        generate_latest,
+    )
+
+    _ENABLED = True
+except ImportError:  # pragma: no cover - exercised only without the extra
+    _ENABLED = False
+
+    # Stub the names we re-export so type checkers / callers don't break.
+    class _NoopMetric:
+        def labels(self, *_args: Any, **_kwargs: Any) -> _NoopMetric:
+            return self
+
+        def inc(self, *_args: Any, **_kwargs: Any) -> None: ...
+
+        def dec(self, *_args: Any, **_kwargs: Any) -> None: ...
+
+        def observe(self, *_args: Any, **_kwargs: Any) -> None: ...
+
+        def set(self, *_args: Any, **_kwargs: Any) -> None: ...
+
+    Counter = Gauge = Histogram = _NoopMetric  # type: ignore[misc,assignment]
+    CONTENT_TYPE_LATEST = "text/plain; version=0.0.4; charset=utf-8"
+    REGISTRY = None  # type: ignore[assignment]
+    CollectorRegistry = None  # type: ignore[assignment,misc]
+
+    def generate_latest(_registry: Any = None) -> bytes:  # type: ignore[misc]
+        return b""
+
+
+_INITIALISED = False
+
+
+HTTP_REQUESTS_TOTAL = Counter(
+    "zakuro_http_requests_total",
+    "HTTP requests handled by the worker, by route + status + tenant.",
+    labelnames=("method", "path", "status", "tenant_id"),
+)
+
+
+DISPATCH_LATENCY_SECONDS = Histogram(
+    "zakuro_dispatch_latency_seconds",
+    "End-to-end function dispatch latency (server-side handler wall clock).",
+    labelnames=("worker_id", "tenant_id"),
+    buckets=(0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10),
+)
+
+
+WORKER_QUEUE_DEPTH = Gauge(
+    "zakuro_worker_queue_depth",
+    "Pending jobs in the worker's thread pool.",
+    labelnames=("worker_id",),
+)
+
+
+AUTH_FAILURE_TOTAL = Counter(
+    "zakuro_auth_failure_total",
+    "Authentication or authorisation refusals, by reason (RFC 0002).",
+    labelnames=("reason", "tenant_id"),
+)
+
+
+def init_metrics() -> bool:
+    """Enable metric collection. Returns ``True`` iff prometheus_client is installed.
+
+    Safe to call multiple times. Idempotent. Library code can call this at
+    import time; callers can also call it directly.
+    """
+    global _INITIALISED
+    if _INITIALISED:
+        return _ENABLED
+    _INITIALISED = True
+    return _ENABLED
+
+
+def is_enabled() -> bool:
+    """Return True iff the optional dependency is installed."""
+    return _ENABLED
+
+
+def mount_metrics_endpoint(app: Any, *, path: str = "/metrics") -> None:
+    """Mount ``GET <path>`` on the FastAPI ``app`` returning Prometheus exposition.
+
+    No-op when ``prometheus_client`` is not installed — the endpoint is not
+    added so a probe that hits it gets a 404, which is the right signal
+    that metrics are off (rather than a degraded 200 with empty body).
+    """
+    if not _ENABLED:
+        return
+    from fastapi import Response
+
+    @app.get(path, include_in_schema=False)
+    def _metrics() -> Response:
+        return Response(
+            content=generate_latest(REGISTRY),
+            media_type=CONTENT_TYPE_LATEST,
+        )
+
+
+def observe_dispatch_latency(worker_id: str, tenant_id: str) -> Callable[[], None]:
+    """Return a context-manager-like callable that, when invoked, observes elapsed.
+
+    Usage::
+
+        stop = observe_dispatch_latency("w-1", "tenant-acme")
+        try:
+            run_job()
+        finally:
+            stop()
+    """
+    start = time.perf_counter()
+
+    def _stop() -> None:
+        elapsed = time.perf_counter() - start
+        DISPATCH_LATENCY_SECONDS.labels(worker_id=worker_id, tenant_id=tenant_id).observe(elapsed)
+
+    return _stop
+
+
+def record_http_request(method: str, path: str, status: int, tenant_id: str) -> None:
+    """Increment the HTTP-request counter once per handled request."""
+    HTTP_REQUESTS_TOTAL.labels(
+        method=method, path=path, status=str(status), tenant_id=tenant_id
+    ).inc()
+
+
+def record_auth_failure(reason: str, tenant_id: str = "") -> None:
+    """Record an auth-layer refusal so SLO alerts can spot brute-force noise."""
+    AUTH_FAILURE_TOTAL.labels(reason=reason, tenant_id=tenant_id).inc()
+
+
+def set_worker_queue_depth(worker_id: str, depth: int) -> None:
+    """Set the current queue-depth gauge for *worker_id*."""
+    WORKER_QUEUE_DEPTH.labels(worker_id=worker_id).set(depth)
+
+
+def _reset_for_tests() -> None:
+    """Reset module-level init flag *and* clear all metric values. Test-only."""
+    global _INITIALISED
+    _INITIALISED = False
+    if not _ENABLED:
+        return
+    # Zero the counters so test order doesn't matter.
+    for metric in (
+        HTTP_REQUESTS_TOTAL,
+        DISPATCH_LATENCY_SECONDS,
+        WORKER_QUEUE_DEPTH,
+        AUTH_FAILURE_TOTAL,
+    ):
+        metric.clear()

--- a/zakuro/worker/server.py
+++ b/zakuro/worker/server.py
@@ -22,23 +22,33 @@ except ImportError as exc:
 
 import contextlib
 
-from zakuro.observability import init_logging, init_sentry
+from zakuro.observability import (
+    init_logging,
+    init_metrics,
+    init_sentry,
+    mount_metrics_endpoint,
+)
 from zakuro.wire import WireError
 from zakuro.worker.envelope import unwrap_payload
 from zakuro.worker.executor import execute_function
 
-# Init structured logging + Sentry as early as possible so any exception during
-# app/executor wiring is captured + emitted as JSON. Both are no-ops when their
-# optional dependency is missing (`zakuro-ai[observability]`) or the relevant
-# env var is unset.
+# Init structured logging + Sentry + Prometheus as early as possible so any
+# exception during app/executor wiring is captured + emitted as JSON and
+# metrics are immediately scrapeable. All three are no-ops when their
+# optional dep is missing or the relevant env var is unset.
 init_logging("worker")
 init_sentry("worker")
+init_metrics()
 
 app = FastAPI(
     title="Zakuro Worker",
     description="Worker node for Zakuro distributed computing",
     version="0.2.0",
 )
+
+# /metrics endpoint, no-op when prometheus_client is not installed. Once
+# RFC 0002 lands, gate this on the metrics:read JWT scope.
+mount_metrics_endpoint(app)
 
 # Thread pool for function execution (threads share memory, so instance
 # state in executor._instances is visible to all workers)


### PR DESCRIPTION
## Summary

Closes #124. Second track of [RFC 0003](docs/rfcs/0003-observability-stack.md).

- `zakuro/observability/metrics.py` — four collectors with bounded label cardinality:
  - `zakuro_http_requests_total{method,path,status,tenant_id}` (Counter)
  - `zakuro_dispatch_latency_seconds{worker_id,tenant_id}` (Histogram, 5ms→10s buckets)
  - `zakuro_worker_queue_depth{worker_id}` (Gauge)
  - `zakuro_auth_failure_total{reason,tenant_id}` (Counter) — seeded for RFC 0002.
- `prometheus_client` is optional via `pip install 'zakuro-ai[observability]'`. Missing dep → no-op, `/metrics` 404s rather than silently degrading.
- `mount_metrics_endpoint(app)` registers `GET /metrics` on the FastAPI worker. Once RFC 0002 ships, gate behind the `metrics:read` JWT scope.
- `zakuro/worker/server.py` wires `init_metrics()` + `mount_metrics_endpoint(app)` at import time.
- `tests/observability/test_metrics.py` — 7 tests covering each collector, the FastAPI endpoint, and a name-convention invariant.

**Follow-up** (intentional, not in this PR): auto-record HTTP/dispatch metrics at the `/execute` call sites — one-liner additions; landing the collectors first keeps this PR reviewable in isolation.

## Test plan

- [x] `pytest tests/observability/test_metrics.py` → 7 passed.
- [x] Full suite: 177 passed.
- [x] `ruff check` / `ruff format --check` clean.
- [x] `mypy zakuro/observability/metrics.py` clean.
- [ ] CI runs green.