### PR TITLE
feat(observability): OpenTelemetry tracing via OTLP/HTTP (#123)

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -21,7 +21,8 @@ Python runtime dependencies
 --- Apache 2.0 (1 package(s)) ---
   * ray 2.53.0  <https://github.com/ray-project/ray>
 
---- Apache Software License (5 package(s)) ---
+--- Apache Software License (6 package(s)) ---
+  * googleapis-common-protos 1.75.0  <https://github.com/googleapis/google-cloud-python/tree/main/packages/googleapis-common-protos>
   * minio 7.2.20  <https://github.com/minio/minio-py>
   * pyOpenSSL 26.0.0  <https://pyopenssl.org/>
   * requests 2.32.5  <https://requests.readthedocs.io>
@@ -31,9 +32,21 @@ Python runtime dependencies
 --- Apache Software License; MIT License (1 package(s)) ---
   * uvloop 0.22.1  <UNKNOWN>
 
---- Apache-2.0 (4 package(s)) ---
+--- Apache-2.0 (16 package(s)) ---
   * coverage 7.13.3  <https://github.com/coveragepy/coveragepy>
+  * importlib_metadata 8.7.1  <https://github.com/python/importlib_metadata>
   * msgpack 1.1.2  <https://msgpack.org/>
+  * opentelemetry-api 1.41.1  <https://github.com/open-telemetry/opentelemetry-python/tree/main/opentelemetry-api>
+  * opentelemetry-exporter-otlp-proto-common 1.41.1  <https://github.com/open-telemetry/opentelemetry-python/tree/main/exporter/opentelemetry-exporter-otlp-proto-common>
+  * opentelemetry-exporter-otlp-proto-http 1.41.1  <https://github.com/open-telemetry/opentelemetry-python/tree/main/exporter/opentelemetry-exporter-otlp-proto-http>
+  * opentelemetry-instrumentation 0.62b1  <https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/opentelemetry-instrumentation>
+  * opentelemetry-instrumentation-asgi 0.62b1  <https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-asgi>
+  * opentelemetry-instrumentation-fastapi 0.62b1  <https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-fastapi>
+  * opentelemetry-instrumentation-httpx 0.62b1  <https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-httpx>
+  * opentelemetry-proto 1.41.1  <https://github.com/open-telemetry/opentelemetry-python/tree/main/opentelemetry-proto>
+  * opentelemetry-sdk 1.41.1  <https://github.com/open-telemetry/opentelemetry-python/tree/main/opentelemetry-sdk>
+  * opentelemetry-semantic-conventions 0.62b1  <https://github.com/open-telemetry/opentelemetry-python/tree/main/opentelemetry-semantic-conventions>
+  * opentelemetry-util-http 0.62b1  <https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/util/opentelemetry-util-http>
   * pyspark 4.1.1  <https://github.com/apache/spark/tree/master/python>
   * pytest-asyncio 1.3.0  <https://github.com/pytest-dev/pytest-asyncio>
 
@@ -49,7 +62,8 @@ Python runtime dependencies
 --- BSD (1 package(s)) ---
   * partd 1.4.2  <http://github.com/dask/partd/>
 
---- BSD License (9 package(s)) ---
+--- BSD License (10 package(s)) ---
+  * asgiref 3.11.1  <https://github.com/django/asgiref/>
   * cloudpickle 3.1.2  <https://github.com/cloudpipe/cloudpickle>
   * httpx 0.28.1  <https://github.com/encode/httpx>
   * Jinja2 3.1.6  <https://github.com/pallets/jinja/>
@@ -63,9 +77,10 @@ Python runtime dependencies
 --- BSD License; Public Domain (1 package(s)) ---
   * pycryptodome 3.23.0  <https://www.pycryptodome.org>
 
---- BSD-2-Clause (2 package(s)) ---
+--- BSD-2-Clause (3 package(s)) ---
   * pyasn1 0.6.3  <https://github.com/pyasn1/pyasn1>
   * tblib 3.2.2  <https://python-tblib.readthedocs.io/en/latest/changelog.html>
+  * wrapt 2.1.2  <https://github.com/GrahamDumpleton/wrapt>
 
 --- BSD-3-Clause (16 package(s)) ---
   * aioquic 1.3.0  <https://github.com/aiortc/aioquic>
@@ -85,7 +100,7 @@ Python runtime dependencies
   * uvicorn 0.40.0  <https://uvicorn.dev/>
   * websockets 16.0  <https://github.com/python-websockets/websockets>
 
---- MIT (29 package(s)) ---
+--- MIT (30 package(s)) ---
   * annotated-doc 0.0.4  <https://github.com/fastapi/annotated-doc>
   * anyio 4.12.1  <https://anyio.readthedocs.io/en/stable/versionhistory.html>
   * argon2-cffi 25.1.0  <https://github.com/hynek/argon2-cffi/blob/main/CHANGELOG.md>
@@ -115,6 +130,7 @@ Python runtime dependencies
   * typing-inspection 0.4.2  <https://github.com/pydantic/typing-inspection>
   * urllib3 2.6.3  <https://github.com/urllib3/urllib3/blob/main/CHANGES.rst>
   * virtualenv 20.36.1  <https://github.com/pypa/virtualenv>
+  * zipp 3.23.0  <https://github.com/jaraco/zipp>
 
 --- MIT License (8 package(s)) ---
   * annotated-types 0.7.0  <https://github.com/annotated-types/annotated-types>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,14 @@ observability = [
     # Prometheus client for /metrics. RFC 0003 Track B (#124). No-op when
     # the dep is missing.
     "prometheus_client>=0.20.0",
+    # OpenTelemetry tracing (RFC 0003 Track C, #123). The SDK + OTLP HTTP
+    # exporter ship traces to any OTLP-compatible collector. FastAPI +
+    # httpx auto-instrumentation cover the HTTP transport surface for free;
+    # QUIC requires hand-rolled spans (zakuro.observability.tracing).
+    "opentelemetry-sdk>=1.27.0",
+    "opentelemetry-exporter-otlp-proto-http>=1.27.0",
+    "opentelemetry-instrumentation-fastapi>=0.48b0",
+    "opentelemetry-instrumentation-httpx>=0.48b0",
 ]
 dev = [
     "pytest>=7.0",

--- a/tests/observability/test_tracing.py
+++ b/tests/observability/test_tracing.py
@@ -1,0 +1,80 @@
+"""Unit tests for the OpenTelemetry tracing surface (#123, RFC 0003 Track C)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from zakuro.observability import tracing as obs_tracing
+
+pytest.importorskip("opentelemetry.sdk", reason="needs [observability] extra")
+
+
+@pytest.fixture(autouse=True)
+def _reset_tracing(monkeypatch: pytest.MonkeyPatch) -> Any:
+    obs_tracing._reset_for_tests()
+    # Avoid leaking real env into tests
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+    monkeypatch.delenv("OTEL_TRACES_SAMPLER_ARG", raising=False)
+    monkeypatch.delenv("OTEL_RESOURCE_ATTRIBUTES", raising=False)
+    yield
+    # Drop the global provider so the background BatchSpanProcessor stops
+    # retrying export against the fake endpoint and polluting the test log.
+    from opentelemetry import trace as _trace
+    from opentelemetry.sdk.trace import TracerProvider
+
+    provider = _trace.get_tracer_provider()
+    if isinstance(provider, TracerProvider):
+        provider.shutdown()
+        _trace._TRACER_PROVIDER = None  # type: ignore[attr-defined]
+    obs_tracing._reset_for_tests()
+
+
+def test_is_enabled_reports_sdk_presence() -> None:
+    assert obs_tracing.is_enabled() is True
+
+
+def test_init_tracing_noop_when_endpoint_unset() -> None:
+    assert obs_tracing.init_tracing("worker") is False
+
+
+def test_init_tracing_wires_provider_when_endpoint_set() -> None:
+    assert obs_tracing.init_tracing("worker", endpoint="http://127.0.0.1:1") is True
+
+
+def test_init_tracing_is_idempotent() -> None:
+    obs_tracing.init_tracing("worker", endpoint="http://127.0.0.1:1")
+    # second call must not raise; returns the enabled bool
+    assert obs_tracing.init_tracing("worker", endpoint="http://127.0.0.1:1") is True
+
+
+def test_get_tracer_returns_a_usable_object() -> None:
+    obs_tracing.init_tracing("worker", endpoint="http://127.0.0.1:1")
+    tracer = obs_tracing.get_tracer("zakuro.test")
+    with tracer.start_as_current_span("zakuro.worker.execute") as span:
+        span.set_attribute("tenant_id", "tenant-acme")
+
+
+def test_get_tracer_returns_noop_when_not_initialised() -> None:
+    """If init_tracing wasn't called, get_tracer still returns something usable.
+
+    The fallback path is exercised by passing through the noop tracer in the
+    no-endpoint case so caller code doesn't have to special-case enabled vs not.
+    """
+    tracer = obs_tracing.get_tracer("zakuro.test")
+    # Real tracer from a still-initialised global provider is OK too — both
+    # must be safe to use. We just check the context manager works.
+    with tracer.start_as_current_span("zakuro.worker.execute") as span:
+        span.set_attribute("k", "v")
+
+
+def test_parse_resource_attributes() -> None:
+    assert obs_tracing._parse_resource_attributes("a=1,b=2,empty") == {"a": "1", "b": "2"}
+    assert obs_tracing._parse_resource_attributes("") == {}
+    assert obs_tracing._parse_resource_attributes(" key = value ") == {"key": "value"}
+
+
+def test_sample_rate_overrides() -> None:
+    obs_tracing._reset_for_tests()
+    assert obs_tracing.init_tracing("worker", endpoint="http://c", sample_rate=1.0) is True

--- a/zakuro/__init__.py
+++ b/zakuro/__init__.py
@@ -14,7 +14,7 @@ Example:
     >>> result = remote_fn()  # Runs on Zakuro cluster
 """
 
-__version__ = "0.2.21"
+__version__ = "0.2.22"
 __build__ = "2026-02-15T15:47:22+0000"
 
 # Stable subset — see `docs/stability.md`. `zakuro.public` is the preferred

--- a/zakuro/observability/__init__.py
+++ b/zakuro/observability/__init__.py
@@ -10,10 +10,8 @@ Currently wired:
 - ``init_sentry`` / ``set_request_context`` — error reporting (#128).
 - ``init_logging`` / ``get_logger`` — structured JSON logs (#125, RFC 0003 Track A).
 - ``init_metrics`` + ``mount_metrics_endpoint`` — Prometheus (#124, RFC 0003 Track B).
-
-Forthcoming:
-
-- ``init_tracing`` — OpenTelemetry tracing (#123).
+- ``init_tracing`` / ``get_tracer`` / ``instrument_fastapi_app`` /
+  ``instrument_httpx`` — OpenTelemetry tracing (#123, RFC 0003 Track C).
 """
 
 from zakuro.observability.logging import get_logger, init_logging
@@ -33,6 +31,15 @@ from zakuro.observability.metrics import (
     is_enabled as metrics_enabled,
 )
 from zakuro.observability.sentry import init_sentry, set_request_context
+from zakuro.observability.tracing import (
+    get_tracer,
+    init_tracing,
+    instrument_fastapi_app,
+    instrument_httpx,
+)
+from zakuro.observability.tracing import (
+    is_enabled as tracing_enabled,
+)
 
 __all__ = [
     "AUTH_FAILURE_TOTAL",
@@ -40,9 +47,13 @@ __all__ = [
     "HTTP_REQUESTS_TOTAL",
     "WORKER_QUEUE_DEPTH",
     "get_logger",
+    "get_tracer",
     "init_logging",
     "init_metrics",
     "init_sentry",
+    "init_tracing",
+    "instrument_fastapi_app",
+    "instrument_httpx",
     "metrics_enabled",
     "mount_metrics_endpoint",
     "observe_dispatch_latency",
@@ -50,4 +61,5 @@ __all__ = [
     "record_http_request",
     "set_request_context",
     "set_worker_queue_depth",
+    "tracing_enabled",
 ]

--- a/zakuro/observability/tracing.py
+++ b/zakuro/observability/tracing.py
@@ -1,0 +1,204 @@
+"""OpenTelemetry tracing for Zakuro (closes #123 — RFC 0003 Track C).
+
+Design notes:
+
+* The single entry point is :func:`init_tracing`. It wires an OTLP/HTTP
+  tracer provider against the standard ``OTEL_EXPORTER_OTLP_ENDPOINT``
+  environment variable (so the same OTel-conformant env vars
+  configure us as any other OTel SDK consumer).
+* Sampling defaults to **10%** via :class:`TraceIdRatioBased`. Override
+  via ``OTEL_TRACES_SAMPLER_ARG`` (e.g. ``0.5`` for 50%, ``1.0`` for
+  always-on during incident investigation).
+* When ``opentelemetry-sdk`` is not installed *or* the endpoint env var
+  is unset, :func:`init_tracing` is a no-op that returns ``False``. The
+  rest of the library still imports cleanly. This keeps the
+  observability extra truly opt-in (matches :func:`init_sentry`,
+  :func:`init_metrics`).
+* :func:`instrument_fastapi_app` calls the FastAPI instrumentation if
+  available so the worker's HTTP transport surface is covered without
+  hand-rolled middleware.
+* :func:`get_tracer` returns a tracer rooted at the ``zakuro.<component>``
+  namespace. QUIC handlers and broker code start spans through it using
+  the conventional names from the RFC:
+
+      zakuro.client.execute
+      zakuro.worker.execute
+      zakuro.adaptive.pick_worker
+      zakuro.wire.pack / unpack
+
+  Trace-id is propagated via the W3C ``traceparent`` header on every
+  outbound HTTP call once :func:`instrument_httpx` runs at startup —
+  spans automatically stitch across broker -> worker hops.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+try:  # opentelemetry-sdk is an optional dependency
+    from opentelemetry import trace
+    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+    from opentelemetry.sdk.resources import Resource
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import BatchSpanProcessor
+    from opentelemetry.sdk.trace.sampling import TraceIdRatioBased
+
+    _ENABLED = True
+except ImportError:  # pragma: no cover - exercised only without the extra
+    _ENABLED = False
+    trace = None  # type: ignore[assignment]
+
+
+_INITIALISED = False
+_DEFAULT_SAMPLE_RATE = 0.1
+
+
+def init_tracing(
+    component: str,
+    *,
+    endpoint: str | None = None,
+    sample_rate: float | None = None,
+) -> bool:
+    """Initialise OTLP/HTTP tracing for *component*.
+
+    *component* names the service in the resource attributes
+    (``service.name = "zakuro.<component>"``).
+
+    *endpoint* overrides the resolved ``OTEL_EXPORTER_OTLP_ENDPOINT``.
+    Pass an explicit value in tests to point at a local collector.
+
+    *sample_rate* overrides ``OTEL_TRACES_SAMPLER_ARG`` (default 0.1).
+
+    Returns ``True`` iff a tracer provider was actually wired in.
+    Returns ``False`` when:
+
+      - ``opentelemetry-sdk`` is not installed (extra missing), or
+      - no endpoint is configured (worker is intentionally off-OTel).
+
+    Safe to call multiple times — second call is a no-op.
+    """
+    global _INITIALISED
+    if _INITIALISED:
+        return _ENABLED
+    if not _ENABLED:
+        return False
+
+    resolved_endpoint = endpoint or os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT", "").strip()
+    if not resolved_endpoint:
+        # Caller explicitly didn't configure an endpoint — that's the
+        # "off" signal. No tracer provider so spans become no-ops.
+        return False
+
+    if sample_rate is None:
+        raw = os.environ.get("OTEL_TRACES_SAMPLER_ARG")
+        sample_rate = _DEFAULT_SAMPLE_RATE if raw is None else _parse_float(raw)
+
+    resource = Resource.create(
+        {
+            "service.name": f"zakuro.{component}",
+            "service.version": _read_version(),
+            **_parse_resource_attributes(os.environ.get("OTEL_RESOURCE_ATTRIBUTES", "")),
+        }
+    )
+    provider = TracerProvider(
+        resource=resource,
+        sampler=TraceIdRatioBased(max(0.0, min(1.0, sample_rate))),
+    )
+    provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter(endpoint=resolved_endpoint)))
+    trace.set_tracer_provider(provider)
+    _INITIALISED = True
+    return True
+
+
+def is_enabled() -> bool:
+    """Return True iff opentelemetry-sdk is installed."""
+    return _ENABLED
+
+
+def get_tracer(name: str) -> Any:
+    """Return an OTel tracer or a no-op stub when the SDK is missing."""
+    if not _ENABLED:
+        return _NoopTracer()
+    return trace.get_tracer(name)
+
+
+def instrument_fastapi_app(app: Any) -> bool:
+    """Apply OTel auto-instrumentation to a FastAPI app, if the extra is installed.
+
+    Returns ``True`` iff instrumentation was applied.
+    """
+    if not _ENABLED:
+        return False
+    try:
+        from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+    except ImportError:
+        return False
+    FastAPIInstrumentor.instrument_app(app)
+    return True
+
+
+def instrument_httpx() -> bool:
+    """Apply OTel auto-instrumentation to httpx clients, if available.
+
+    Auto-injects ``traceparent`` on every outbound HTTP call so spans
+    stitch across the broker -> worker hop without code changes.
+    """
+    if not _ENABLED:
+        return False
+    try:
+        from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
+    except ImportError:
+        return False
+    HTTPXClientInstrumentor().instrument()
+    return True
+
+
+def _parse_float(raw: str) -> float:
+    try:
+        return float(raw)
+    except ValueError:
+        return _DEFAULT_SAMPLE_RATE
+
+
+def _parse_resource_attributes(raw: str) -> dict[str, str]:
+    """Parse the W3C-style ``key1=value1,key2=value2`` env var."""
+    out: dict[str, str] = {}
+    for chunk in raw.split(","):
+        if "=" not in chunk:
+            continue
+        key, value = chunk.split("=", 1)
+        out[key.strip()] = value.strip()
+    return out
+
+
+def _read_version() -> str:
+    try:
+        from zakuro import __version__
+    except ImportError:
+        return "0.0.0"
+    return __version__
+
+
+class _NoopTracer:
+    """Minimal stand-in returned when the SDK is not installed."""
+
+    def start_as_current_span(self, _name: str, **_kwargs: Any) -> _NoopSpanCtx:
+        return _NoopSpanCtx()
+
+
+class _NoopSpanCtx:
+    def __enter__(self) -> _NoopSpanCtx:
+        return self
+
+    def __exit__(self, *_exc: Any) -> None: ...
+
+    def set_attribute(self, _key: str, _value: Any) -> None: ...
+
+    def record_exception(self, _exc: BaseException) -> None: ...
+
+
+def _reset_for_tests() -> None:
+    """Reset module init flag. Test-only — do not call in prod."""
+    global _INITIALISED
+    _INITIALISED = False

--- a/zakuro/worker/server.py
+++ b/zakuro/worker/server.py
@@ -26,19 +26,23 @@ from zakuro.observability import (
     init_logging,
     init_metrics,
     init_sentry,
+    init_tracing,
+    instrument_fastapi_app,
+    instrument_httpx,
     mount_metrics_endpoint,
 )
 from zakuro.wire import WireError
 from zakuro.worker.envelope import unwrap_payload
 from zakuro.worker.executor import execute_function
 
-# Init structured logging + Sentry + Prometheus as early as possible so any
-# exception during app/executor wiring is captured + emitted as JSON and
-# metrics are immediately scrapeable. All three are no-ops when their
-# optional dep is missing or the relevant env var is unset.
+# Init structured logging + Sentry + Prometheus + OpenTelemetry as early as
+# possible. All four are no-ops when their optional dep is missing or the
+# relevant env var (SENTRY_DSN / OTEL_EXPORTER_OTLP_ENDPOINT) is unset.
 init_logging("worker")
 init_sentry("worker")
 init_metrics()
+init_tracing("worker")
+instrument_httpx()  # outbound calls carry W3C traceparent for cross-hop stitching
 
 app = FastAPI(
     title="Zakuro Worker",
@@ -49,6 +53,10 @@ app = FastAPI(
 # /metrics endpoint, no-op when prometheus_client is not installed. Once
 # RFC 0002 lands, gate this on the metrics:read JWT scope.
 mount_metrics_endpoint(app)
+
+# FastAPI auto-instrumentation; no-op when the extra is missing. Must run AFTER
+# the FastAPI app object exists.
+instrument_fastapi_app(app)
 
 # Thread pool for function execution (threads share memory, so instance
 # state in executor._instances is visible to all workers)


### PR DESCRIPTION
## Summary

Closes #123. Third track of [RFC 0003](docs/rfcs/0003-observability-stack.md).

- `zakuro/observability/tracing.py` — `init_tracing(component)` wires an OTLP/HTTP tracer provider against `OTEL_EXPORTER_OTLP_ENDPOINT`. 10% sampling default, `OTEL_TRACES_SAMPLER_ARG` overrides.
- `opentelemetry-sdk` + OTLP proto-http exporter + FastAPI / httpx auto-instrumentations added to the `[observability]` extra. All no-ops when missing.
- `instrument_httpx()` makes outbound HTTP calls carry the W3C `traceparent` header so spans stitch across broker → worker without code changes.
- `zakuro/worker/server.py` wires `init_tracing("worker")` + `instrument_httpx()` at import time and `instrument_fastapi_app(app)` after FastAPI is constructed.
- `tests/observability/test_tracing.py` — 8 tests; teardown shuts the provider so test log stays clean.

Span naming follows the RFC: `zakuro.client.execute`, `zakuro.worker.execute`, `zakuro.adaptive.pick_worker`, `zakuro.wire.pack/unpack`. Call-site instrumentation lands as one-liner additions in follow-up.

## Test plan

- [x] `pytest tests/observability/test_tracing.py` → 8 passed, clean output.
- [x] Full suite: 178 passed.
- [x] `ruff check` / `ruff format --check` clean.
- [x] `mypy zakuro/observability/tracing.py` clean.
- [ ] CI runs green.