### PR TITLE
feat(auth): Ed25519 JWT verification + FastAPI scope middleware (#116 Phase 1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,9 @@ worker = [
     "uvicorn[standard]>=0.23.0",
     "psutil>=5.9.0",
     "aioquic>=1.0.0",
+    # PyJWT for Ed25519 JWT verification (RFC 0002, #116). The cryptography
+    # extra pulls in pyca/cryptography needed for asymmetric algorithms.
+    "PyJWT[crypto]>=2.8.0",
 ]
 ray = ["ray>=2.0.0"]
 dask = ["dask>=2023.0.0", "distributed>=2023.0.0"]

--- a/tests/auth/conftest.py
+++ b/tests/auth/conftest.py
@@ -1,0 +1,33 @@
+"""FastAPI test app shared across the auth-middleware tests.
+
+The ``Depends(...)`` markers are passed as default-value rather than
+via ``Annotated[..., Depends(...)]`` because nesting the function-style
+build inside another function defeats FastAPI's annotation
+introspection in some Python/FastAPI version combinations — the Depends
+metadata in ``Annotated[].__metadata__`` is silently dropped, the
+parameter becomes a regular query-string field, and every endpoint
+returns 422.
+"""
+
+from __future__ import annotations
+
+from fastapi import Depends, FastAPI
+
+from zakuro.auth import require_jwt_scope
+
+
+def build_auth_app() -> FastAPI:
+    app = FastAPI()
+
+    exec_dep = require_jwt_scope("exec:fn")
+    admin_dep = require_jwt_scope("admin:credits")
+
+    @app.post("/execute")
+    async def execute(claims=Depends(exec_dep)):  # type: ignore[no-untyped-def]  # noqa: B008
+        return {"tenant": claims.tenant_id}
+
+    @app.get("/admin")
+    async def admin(claims=Depends(admin_dep)):  # type: ignore[no-untyped-def]  # noqa: B008
+        return {"tenant": claims.tenant_id}
+
+    return app

--- a/tests/auth/test_jwt.py
+++ b/tests/auth/test_jwt.py
@@ -1,0 +1,201 @@
+"""Unit tests for JWT verification + HKDF derivation (#116, RFC 0002)."""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import jwt as pyjwt
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from zakuro.auth.jwt import (
+    Claims,
+    JwtError,
+    JwtExpiredError,
+    JwtSignatureError,
+    derive_payload_hmac_key,
+    verify_jwt,
+)
+
+
+@pytest.fixture
+def signing_keys() -> Any:
+    private = Ed25519PrivateKey.generate()
+    public = private.public_key()
+    private_pem = private.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    public_pem = public.public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return private_pem, public_pem
+
+
+def _issue(
+    private_pem: bytes,
+    *,
+    tenant_id: str = "tenant-acme",
+    worker_id: str = "worker-1",
+    scopes: list[str] | None = None,
+    aud: str = "zakuro-worker",
+    exp_delta: int = 900,
+    nbf_delta: int = 0,
+    jti: str = "j-1",
+) -> str:
+    now = int(time.time())
+    payload = {
+        "iss": "broker",
+        "aud": aud,
+        "iat": now,
+        "nbf": now + nbf_delta,
+        "exp": now + exp_delta,
+        "jti": jti,
+        "tenant_id": tenant_id,
+        "worker_id": worker_id,
+        "scopes": scopes if scopes is not None else ["exec:fn"],
+    }
+    return pyjwt.encode(payload, private_pem, algorithm="EdDSA")
+
+
+def test_verify_jwt_happy_path(signing_keys: Any) -> None:
+    private_pem, public_pem = signing_keys
+    token = _issue(private_pem)
+    claims = verify_jwt(token, expected_audience="zakuro-worker", public_key_pem=public_pem)
+    assert isinstance(claims, Claims)
+    assert claims.tenant_id == "tenant-acme"
+    assert claims.has_scope("exec:fn")
+    assert not claims.has_scope("admin:credits")
+
+
+def test_verify_jwt_rejects_expired_token(signing_keys: Any) -> None:
+    private_pem, public_pem = signing_keys
+    token = _issue(private_pem, exp_delta=-10)
+    with pytest.raises(JwtExpiredError):
+        verify_jwt(token, expected_audience="zakuro-worker", public_key_pem=public_pem)
+
+
+def test_verify_jwt_rejects_wrong_audience(signing_keys: Any) -> None:
+    private_pem, public_pem = signing_keys
+    token = _issue(private_pem, aud="zakuro-dashboard")
+    with pytest.raises(JwtSignatureError):
+        verify_jwt(token, expected_audience="zakuro-worker", public_key_pem=public_pem)
+
+
+def test_verify_jwt_rejects_wrong_signing_key(signing_keys: Any) -> None:
+    private_pem, _ = signing_keys
+    # Generate a second, unrelated public key
+    other_public = (
+        Ed25519PrivateKey.generate()
+        .public_key()
+        .public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+    )
+    token = _issue(private_pem)
+    with pytest.raises(JwtSignatureError):
+        verify_jwt(token, expected_audience="zakuro-worker", public_key_pem=other_public)
+
+
+def test_verify_jwt_rejects_alg_confusion(signing_keys: Any) -> None:
+    _, public_pem = signing_keys
+    # Forge an HS256 token using *any* secret. The classic alg-confusion
+    # attack relies on the verifier accepting HS256, regardless of which
+    # secret was used. `algorithms=["EdDSA"]` blocks it at parse time.
+    # (PyJWT itself refuses to use an asymmetric key as an HS256 secret
+    # at encode time — so we encode with a plain bytes secret here.)
+    now = int(time.time())
+    forged = pyjwt.encode(
+        {
+            "aud": "zakuro-worker",
+            "exp": now + 60,
+            "nbf": now,
+            "jti": "x",
+            "tenant_id": "tenant",
+            "worker_id": "worker",
+            "scopes": ["exec:fn"],
+        },
+        b"any-secret",
+        algorithm="HS256",
+    )
+    with pytest.raises(JwtSignatureError):
+        verify_jwt(forged, expected_audience="zakuro-worker", public_key_pem=public_pem)
+
+
+def test_verify_jwt_rejects_token_for_wrong_worker(signing_keys: Any) -> None:
+    private_pem, public_pem = signing_keys
+    token = _issue(private_pem, worker_id="worker-1")
+    with pytest.raises(JwtSignatureError):
+        verify_jwt(
+            token,
+            expected_audience="zakuro-worker",
+            expected_worker_id="worker-2",
+            public_key_pem=public_pem,
+        )
+
+
+def test_verify_jwt_rejects_missing_required_claims(signing_keys: Any) -> None:
+    private_pem, public_pem = signing_keys
+    now = int(time.time())
+    # No `nbf` — verify_jwt requires it via options["require"]
+    token = pyjwt.encode(
+        {
+            "aud": "zakuro-worker",
+            "exp": now + 60,
+            "jti": "x",
+            "tenant_id": "tenant",
+            "worker_id": "worker",
+            "scopes": ["exec:fn"],
+        },
+        private_pem,
+        algorithm="EdDSA",
+    )
+    with pytest.raises(JwtError):
+        verify_jwt(token, expected_audience="zakuro-worker", public_key_pem=public_pem)
+
+
+def test_verify_jwt_rejects_malformed_scopes(signing_keys: Any) -> None:
+    private_pem, public_pem = signing_keys
+    # scopes as a string rather than a list
+    now = int(time.time())
+    token = pyjwt.encode(
+        {
+            "aud": "zakuro-worker",
+            "exp": now + 60,
+            "nbf": now,
+            "jti": "x",
+            "tenant_id": "tenant",
+            "worker_id": "worker",
+            "scopes": "exec:fn",
+        },
+        private_pem,
+        algorithm="EdDSA",
+    )
+    with pytest.raises(JwtError, match="scopes"):
+        verify_jwt(token, expected_audience="zakuro-worker", public_key_pem=public_pem)
+
+
+def test_derive_payload_hmac_key_is_deterministic() -> None:
+    key = b"x" * 32
+    a = derive_payload_hmac_key(jwt_signing_key=key, tenant_id="tenant-acme")
+    b = derive_payload_hmac_key(jwt_signing_key=key, tenant_id="tenant-acme")
+    assert a == b
+    assert len(a) == 32
+
+
+def test_derive_payload_hmac_key_diverges_by_tenant() -> None:
+    key = b"x" * 32
+    a = derive_payload_hmac_key(jwt_signing_key=key, tenant_id="tenant-a")
+    b = derive_payload_hmac_key(jwt_signing_key=key, tenant_id="tenant-b")
+    assert a != b
+
+
+def test_derive_payload_hmac_key_diverges_by_signing_key() -> None:
+    a = derive_payload_hmac_key(jwt_signing_key=b"a" * 32, tenant_id="t")
+    b = derive_payload_hmac_key(jwt_signing_key=b"b" * 32, tenant_id="t")
+    assert a != b

--- a/tests/auth/test_middleware.py
+++ b/tests/auth/test_middleware.py
@@ -1,0 +1,112 @@
+"""FastAPI dependency tests for require_jwt_scope (#116, RFC 0002)."""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import jwt as pyjwt
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from fastapi.testclient import TestClient
+
+from tests.auth.conftest import build_auth_app as _build_app
+
+
+@pytest.fixture
+def signing_keys() -> Any:
+    private = Ed25519PrivateKey.generate()
+    public = private.public_key()
+    private_pem = private.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    public_pem = public.public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return private_pem, public_pem
+
+
+def _issue(private_pem: bytes, *, scopes: list[str], worker_id: str = "worker-1") -> str:
+    now = int(time.time())
+    return pyjwt.encode(
+        {
+            "aud": "zakuro-worker",
+            "exp": now + 900,
+            "nbf": now,
+            "jti": "j-1",
+            "tenant_id": "tenant-acme",
+            "worker_id": worker_id,
+            "scopes": scopes,
+        },
+        private_pem,
+        algorithm="EdDSA",
+    )
+
+
+def test_returns_anonymous_when_auth_not_required(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ZAKURO_AUTH_REQUIRED", raising=False)
+    app = _build_app()
+    client = TestClient(app)
+    r = client.post("/execute")
+    assert r.status_code == 200
+    assert r.json() == {"tenant": "anonymous"}
+
+
+def test_rejects_when_required_and_no_token(
+    monkeypatch: pytest.MonkeyPatch, signing_keys: Any
+) -> None:
+    _, public_pem = signing_keys
+    monkeypatch.setenv("ZAKURO_AUTH_REQUIRED", "1")
+    monkeypatch.setenv("ZAKURO_JWT_PUBLIC_KEY_PEM", public_pem.decode())
+    monkeypatch.setenv("ZAKURO_WORKER_ID", "worker-1")
+    app = _build_app()
+    r = TestClient(app).post("/execute")
+    assert r.status_code == 401
+
+
+def test_accepts_valid_token_with_required_scope(
+    monkeypatch: pytest.MonkeyPatch, signing_keys: Any
+) -> None:
+    private_pem, public_pem = signing_keys
+    monkeypatch.setenv("ZAKURO_AUTH_REQUIRED", "1")
+    monkeypatch.setenv("ZAKURO_JWT_PUBLIC_KEY_PEM", public_pem.decode())
+    monkeypatch.setenv("ZAKURO_WORKER_ID", "worker-1")
+    token = _issue(private_pem, scopes=["exec:fn"])
+    r = TestClient(_build_app()).post("/execute", headers={"Authorization": f"Bearer {token}"})
+    assert r.status_code == 200
+    assert r.json() == {"tenant": "tenant-acme"}
+
+
+def test_rejects_token_missing_required_scope(
+    monkeypatch: pytest.MonkeyPatch, signing_keys: Any
+) -> None:
+    private_pem, public_pem = signing_keys
+    monkeypatch.setenv("ZAKURO_AUTH_REQUIRED", "1")
+    monkeypatch.setenv("ZAKURO_JWT_PUBLIC_KEY_PEM", public_pem.decode())
+    monkeypatch.setenv("ZAKURO_WORKER_ID", "worker-1")
+    # Token has exec:fn but the /admin handler wants admin:credits
+    token = _issue(private_pem, scopes=["exec:fn"])
+    r = TestClient(_build_app()).get("/admin", headers={"Authorization": f"Bearer {token}"})
+    assert r.status_code == 401
+
+
+def test_rejects_token_for_wrong_worker(monkeypatch: pytest.MonkeyPatch, signing_keys: Any) -> None:
+    private_pem, public_pem = signing_keys
+    monkeypatch.setenv("ZAKURO_AUTH_REQUIRED", "1")
+    monkeypatch.setenv("ZAKURO_JWT_PUBLIC_KEY_PEM", public_pem.decode())
+    monkeypatch.setenv("ZAKURO_WORKER_ID", "worker-2")
+    token = _issue(private_pem, scopes=["exec:fn"], worker_id="worker-1")
+    r = TestClient(_build_app()).post("/execute", headers={"Authorization": f"Bearer {token}"})
+    assert r.status_code == 401
+
+
+def test_rejects_malformed_authorization_header(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ZAKURO_AUTH_REQUIRED", "1")
+    monkeypatch.setenv("ZAKURO_JWT_PUBLIC_KEY_PEM", "-----BEGIN PUBLIC KEY-----")
+    monkeypatch.setenv("ZAKURO_WORKER_ID", "worker-1")
+    r = TestClient(_build_app()).post("/execute", headers={"Authorization": "Basic dXNlcjpwYXNz"})
+    assert r.status_code == 401

--- a/zakuro/auth/__init__.py
+++ b/zakuro/auth/__init__.py
@@ -1,0 +1,37 @@
+"""Authentication and authorisation surface for Zakuro (#116, RFC 0002).
+
+This package implements the request-side of the runtime's auth model:
+
+- :func:`verify_jwt` — parse + verify an Ed25519-signed JWT issued by the
+  broker, returning :class:`Claims` on success.
+- :func:`derive_payload_hmac_key` — HKDF-derive the per-tenant key the
+  worker uses to verify postcard-envelope HMACs (#117).
+- :func:`require_jwt_scope` — FastAPI dependency that gates a handler on
+  a specific JWT scope.
+
+The transport-level mTLS layer lives in :mod:`zakuro.transport` (#115).
+This package assumes mTLS has already verified the peer; JWTs add the
+per-request authorisation on top.
+"""
+
+from zakuro.auth.jwt import (
+    Claims,
+    JwtError,
+    JwtExpiredError,
+    JwtScopeError,
+    JwtSignatureError,
+    derive_payload_hmac_key,
+    verify_jwt,
+)
+from zakuro.auth.middleware import require_jwt_scope
+
+__all__ = [
+    "Claims",
+    "JwtError",
+    "JwtExpiredError",
+    "JwtScopeError",
+    "JwtSignatureError",
+    "derive_payload_hmac_key",
+    "require_jwt_scope",
+    "verify_jwt",
+]

--- a/zakuro/auth/jwt.py
+++ b/zakuro/auth/jwt.py
@@ -1,0 +1,206 @@
+"""Ed25519 JWT verification + HMAC-key derivation (RFC 0002 / #116).
+
+Design notes
+------------
+
+* The worker only ever **verifies** JWTs — it never issues them. The
+  broker (zc) is the issuer (RFC 0002 §"JWT issuance"). The worker's
+  public verification key is bundled at build time + can be rotated
+  via the gossip handshake (RFC 0008).
+* Verification uses PyJWT with `algorithms=["EdDSA"]` exclusively to
+  block the classic alg-confusion attacks (`{"alg": "none"}`,
+  `{"alg": "HS256"}` against a public key, etc.).
+* Required claims: ``aud``, ``exp``, ``nbf``, ``jti``, ``tenant_id``,
+  ``worker_id``, ``scopes``. Verification fails closed if any are
+  absent or malformed.
+* The HMAC key for the postcard envelope's signature (#117) is HKDF-
+  derived from the JWT signing key by the broker; the worker receives
+  it directly via the same channel that issued the JWT. The
+  :func:`derive_payload_hmac_key` helper performs that HKDF locally so
+  unit tests don't have to spin up a broker.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any
+
+try:
+    import jwt as _pyjwt
+    from jwt.exceptions import (
+        ExpiredSignatureError,
+        InvalidAudienceError,
+        InvalidSignatureError,
+        InvalidTokenError,
+        MissingRequiredClaimError,
+    )
+except ImportError as exc:  # pragma: no cover - exercised only without the extra
+    raise ImportError(
+        "Verifying Zakuro JWTs requires the `[worker]` extra "
+        "(PyJWT[crypto]). Install it with `pip install 'zakuro-ai[worker]'`."
+    ) from exc
+
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+
+_HMAC_KEY_LENGTH = 32
+_HKDF_SALT = b"zakuro-wire-v1"
+
+
+class JwtError(Exception):
+    """Base for any JWT-related failure."""
+
+
+class JwtExpiredError(JwtError):
+    """Token's ``exp`` claim has passed."""
+
+
+class JwtSignatureError(JwtError):
+    """Token signature did not validate against the configured public key."""
+
+
+class JwtScopeError(JwtError):
+    """Token did not include the required scope."""
+
+
+@dataclass(frozen=True)
+class Claims:
+    """The validated claims a Zakuro JWT carries."""
+
+    tenant_id: str
+    worker_id: str
+    scopes: frozenset[str]
+    jti: str
+    exp: int
+    nbf: int
+    aud: str
+
+    def has_scope(self, scope: str) -> bool:
+        return scope in self.scopes
+
+
+def _public_key_from_env() -> bytes:
+    """Read the broker's Ed25519 public key from ``ZAKURO_JWT_PUBLIC_KEY_PEM`` or its path.
+
+    The env var may carry either the PEM string directly (multi-line) or a
+    filesystem path. A missing value raises :class:`JwtSignatureError`
+    rather than returning ``None`` — refusing all tokens is the right
+    failure mode when the worker can't know who signed them.
+    """
+    raw = os.environ.get("ZAKURO_JWT_PUBLIC_KEY_PEM", "").strip()
+    if not raw:
+        raise JwtSignatureError(
+            "ZAKURO_JWT_PUBLIC_KEY_PEM is unset — refusing all JWTs. Configure "
+            "the worker with the broker's Ed25519 public key (PEM)."
+        )
+    if raw.startswith("-----BEGIN"):
+        return raw.encode("utf-8")
+    # treat as a path
+    try:
+        with open(raw, "rb") as f:
+            return f.read()
+    except OSError as exc:
+        raise JwtSignatureError(f"could not read public key from {raw}: {exc}") from exc
+
+
+def verify_jwt(
+    token: str,
+    *,
+    expected_audience: str,
+    expected_worker_id: str | None = None,
+    public_key_pem: bytes | None = None,
+    leeway_seconds: int = 0,
+) -> Claims:
+    """Verify a JWT and return its :class:`Claims`.
+
+    Parameters
+    ----------
+    token
+        The bearer token (no ``"Bearer "`` prefix).
+    expected_audience
+        Required ``aud`` claim. A token issued for another component
+        (e.g. the dashboard) fails verification.
+    expected_worker_id
+        If set, the token's ``worker_id`` claim must match. Prevents
+        replay against a different worker in the same tenant.
+    public_key_pem
+        Override the env-resolved public key. Test-only.
+    leeway_seconds
+        Clock-skew tolerance for ``exp`` / ``nbf``.
+
+    Raises :class:`JwtSignatureError`, :class:`JwtExpiredError`, or
+    :class:`JwtError` on any failure. Returns the parsed claims on
+    success.
+    """
+    key = public_key_pem if public_key_pem is not None else _public_key_from_env()
+    try:
+        payload: dict[str, Any] = _pyjwt.decode(
+            token,
+            key,
+            algorithms=["EdDSA"],
+            audience=expected_audience,
+            leeway=leeway_seconds,
+            options={
+                "require": ["exp", "nbf", "jti", "aud"],
+                "verify_aud": True,
+                "verify_exp": True,
+                "verify_nbf": True,
+            },
+        )
+    except ExpiredSignatureError as exc:
+        raise JwtExpiredError(str(exc)) from exc
+    except (InvalidSignatureError, InvalidTokenError, InvalidAudienceError) as exc:
+        raise JwtSignatureError(str(exc)) from exc
+    except MissingRequiredClaimError as exc:
+        raise JwtError(str(exc)) from exc
+
+    try:
+        tenant_id = str(payload["tenant_id"])
+        worker_id = str(payload["worker_id"])
+        scopes_raw = payload["scopes"]
+        if not isinstance(scopes_raw, (list, tuple)):
+            raise JwtError("scopes claim must be an array")
+        scopes = frozenset(str(s) for s in scopes_raw)
+        jti = str(payload["jti"])
+        exp = int(payload["exp"])
+        nbf = int(payload["nbf"])
+        aud_claim = str(payload["aud"])
+    except (KeyError, TypeError, ValueError) as exc:
+        raise JwtError(f"malformed claim set: {exc}") from exc
+
+    if expected_worker_id is not None and worker_id != expected_worker_id:
+        raise JwtSignatureError(
+            f"token issued for worker_id={worker_id!r}, this worker is {expected_worker_id!r}"
+        )
+
+    return Claims(
+        tenant_id=tenant_id,
+        worker_id=worker_id,
+        scopes=scopes,
+        jti=jti,
+        exp=exp,
+        nbf=nbf,
+        aud=aud_claim,
+    )
+
+
+def derive_payload_hmac_key(*, jwt_signing_key: bytes, tenant_id: str) -> bytes:
+    """HKDF-derive the per-tenant key used to verify postcard-envelope HMACs.
+
+    Matches the Rust crate's expected derivation:
+    ``HKDF-SHA256(jwt_signing_key, salt="zakuro-wire-v1", info=f"payload:{tenant_id}")``.
+
+    This is called by the broker per-tenant + bundled with the dispatch;
+    the worker also derives it from its own copy of the broker's signing
+    key when verifying. Same algorithm, same result.
+    """
+    if not jwt_signing_key:
+        raise JwtError("jwt_signing_key must not be empty")
+    hkdf = HKDF(
+        algorithm=hashes.SHA256(),
+        length=_HMAC_KEY_LENGTH,
+        salt=_HKDF_SALT,
+        info=f"payload:{tenant_id}".encode(),
+    )
+    return hkdf.derive(jwt_signing_key)

--- a/zakuro/auth/middleware.py
+++ b/zakuro/auth/middleware.py
@@ -1,0 +1,135 @@
+"""FastAPI dependency that gates a handler on a required JWT scope (#116, RFC 0002).
+
+Usage in handlers::
+
+    from fastapi import Depends
+    from zakuro.auth import require_jwt_scope, Claims
+
+    @app.post("/execute")
+    async def execute(claims: Claims = Depends(require_jwt_scope("exec:fn"))):
+        ...
+
+The dependency picks the worker's identity from
+``ZAKURO_WORKER_ID`` so a leaked token issued for a sibling worker is
+rejected before any handler runs. Set ``ZAKURO_AUTH_REQUIRED=1`` in the
+environment to enforce; when unset, the dependency returns
+``Claims(... scopes=set(), tenant_id="anonymous")`` — that's the
+opt-in rollout switch from RFC 0002 §"Step 5 — flip strict".
+
+Observability
+-------------
+
+Every auth refusal increments the
+``zakuro_auth_failure_total{reason,tenant_id}`` Prometheus counter so
+operations can spot brute-force patterns (#124, RFC 0003 Track B).
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable
+from typing import Any
+
+try:
+    from fastapi import HTTPException, Request
+except ImportError as exc:  # pragma: no cover
+    raise ImportError("JWT middleware requires the [worker] extra (fastapi).") from exc
+
+from zakuro.auth.jwt import (
+    Claims,
+    JwtError,
+    JwtExpiredError,
+    JwtScopeError,
+    JwtSignatureError,
+    verify_jwt,
+)
+
+_ANONYMOUS_CLAIMS = Claims(
+    tenant_id="anonymous",
+    worker_id="",
+    scopes=frozenset(),
+    jti="",
+    exp=0,
+    nbf=0,
+    aud="",
+)
+
+
+def _auth_required() -> bool:
+    return os.environ.get("ZAKURO_AUTH_REQUIRED", "").strip() in {"1", "true", "yes"}
+
+
+def _record_failure(reason: str, tenant_id: str = "") -> None:
+    """Increment the auth-failure metric — no-op when Prometheus is missing.
+
+    The import is deferred + caught because :mod:`zakuro.observability.metrics`
+    ships in PR #185 (RFC 0003 Track B). When this PR lands before that one,
+    auth still works; metrics just stay at zero until the metrics module
+    is importable.
+    """
+    try:
+        from zakuro.observability.metrics import (  # type: ignore[import-not-found]
+            record_auth_failure,
+        )
+    except ImportError:  # pragma: no cover
+        return
+    record_auth_failure(reason, tenant_id)
+
+
+def require_jwt_scope(required_scope: str) -> Callable[..., Any]:
+    """Return a FastAPI dependency that asserts the JWT carries *required_scope*.
+
+    The dependency:
+
+      1. extracts the bearer token from ``Authorization``;
+      2. verifies the signature, audience, expiry, nbf;
+      3. checks the token's ``scopes`` includes ``required_scope``;
+      4. checks the token's ``worker_id`` matches this worker.
+
+    Failures raise HTTP 401 with no body — leaking the reason would aid
+    enumeration. The reason is recorded in
+    ``zakuro_auth_failure_total`` so operators can still triage.
+
+    When ``ZAKURO_AUTH_REQUIRED`` is unset or falsy, the dependency
+    returns anonymous claims so the handler can still inspect
+    ``claims.tenant_id == "anonymous"`` if it wants to refuse anyway.
+    This is the v0.3 → v0.4 rollout switch (see RFC 0002 §"Step 5").
+    """
+
+    async def _dep(request: Request) -> Claims:
+        if not _auth_required():
+            return _ANONYMOUS_CLAIMS
+        auth_header = request.headers.get("authorization", "")
+        if not auth_header.lower().startswith("bearer "):
+            _record_failure("missing_bearer")
+            raise HTTPException(status_code=401, detail="")
+        token = auth_header.split(" ", 1)[1].strip()
+        worker_id = os.environ.get("ZAKURO_WORKER_ID") or None
+        audience = os.environ.get("ZAKURO_JWT_AUDIENCE", "zakuro-worker")
+        try:
+            claims = verify_jwt(
+                token,
+                expected_audience=audience,
+                expected_worker_id=worker_id,
+                leeway_seconds=int(os.environ.get("ZAKURO_JWT_LEEWAY_SECONDS", "5")),
+            )
+        except JwtExpiredError:
+            _record_failure("expired")
+            raise HTTPException(status_code=401, detail="") from None
+        except JwtSignatureError as exc:
+            _record_failure("signature")
+            raise HTTPException(status_code=401, detail="") from exc
+        except JwtError as exc:
+            _record_failure("malformed")
+            raise HTTPException(status_code=401, detail="") from exc
+
+        if not claims.has_scope(required_scope):
+            _record_failure("scope_denied", claims.tenant_id)
+            raise HTTPException(status_code=401, detail="") from None
+        return claims
+
+    return _dep
+
+
+# Re-exported so callers can `from zakuro.auth import JwtScopeError`.
+__all__ = ["require_jwt_scope", "JwtScopeError"]


### PR DESCRIPTION
## Summary

Closes #116 **Phase 1**. RFC 0002 implementation: JWT verification + FastAPI scope-gating middleware. Phase 2 (wiring onto `/execute` + QUIC handlers) lands separately.

- `zakuro/auth/jwt.py`
  - `verify_jwt(...)` with `algorithms=["EdDSA"]` exclusively — blocks alg-confusion (`alg=none`, `alg=HS256` against a public key).
  - Required claims: `aud`, `exp`, `nbf`, `jti`, `tenant_id`, `worker_id`, `scopes`. Missing or malformed → `JwtError` (fail closed).
  - `expected_worker_id` pins the token to *this* worker.
  - `derive_payload_hmac_key(jwt_signing_key, tenant_id)` — HKDF-SHA256 with `salt="zakuro-wire-v1"`, `info=f"payload:{tenant_id}"`. Matches the Rust crate's documented HMAC derivation; this is the key #117's `safe_loads` consumes.
- `zakuro/auth/middleware.py`
  - `require_jwt_scope("exec:fn")` is a FastAPI dependency. `ZAKURO_AUTH_REQUIRED` toggles enforcement (RFC 0002 §"Step 5 rollout").
  - Failures: HTTP 401 empty body + `zakuro_auth_failure_total{reason,tenant_id}` Prometheus counter (records when #185 metrics module is importable; no-ops otherwise).
  - Default-value `Depends()` over `Annotated[..., Depends(...)]` — documented; the Annotated form drops the marker when used inside function-nested route decls.
- `PyJWT[crypto]>=2.8.0` added to the `[worker]` extra.
- `tests/auth/` — 17 tests total.

## Test plan

- [x] `pytest tests/auth/` → 17 passed.
- [x] Full suite: 187 passed.
- [x] `ruff check` / `ruff format --check` clean.
- [x] `mypy zakuro/auth/` clean.
- [ ] CI runs green.

## Cross-repo

Paired zc PR not strictly required for this PR — zc already issues JWTs (RFC 0002 §"JWT issuance"). The Phase 2 wiring PR will need zc to derive + bundle the per-tenant HMAC key (#117) using the same HKDF parameters; `derive_payload_hmac_key` is the canonical reference both sides match.

## Phase 2 — what's next

Wire `require_jwt_scope("exec:fn")` onto `/execute` (HTTP + QUIC) so `ZAKURO_AUTH_REQUIRED=1` actually gates traffic. Lands after this + #188 (#117 Phase 1) merge.