### PR TITLE
feat(transport): mTLS substrate — cert loading + peer identity (#115 Phase 1)

### DIFF
--- a/tests/transport/test_peer.py
+++ b/tests/transport/test_peer.py
@@ -1,0 +1,80 @@
+"""Tests for peer-identity extraction (#115, RFC 0002)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from zakuro.transport.peer import (
+    PeerIdentity,
+    extract_peer_from_request,
+    parse_x_forwarded_client_cert,
+)
+
+
+class _StubSSLObject:
+    def __init__(self, cert: dict[str, Any] | None) -> None:
+        self._cert = cert
+
+    def getpeercert(self) -> dict[str, Any] | None:
+        return self._cert
+
+
+class _StubRequest:
+    def __init__(
+        self, *, tls_obj: Any | None = None, headers: dict[str, str] | None = None
+    ) -> None:
+        self.scope: dict[str, Any] = {"extensions": {"tls.transport": tls_obj}} if tls_obj else {}
+        self.headers = headers or {}
+
+
+def test_extract_peer_from_direct_mtls() -> None:
+    cert = {
+        "subject": ((("commonName", "tenant-acme/worker-1"),),),
+        "subjectAltName": (
+            ("URI", "spiffe://zakuro.ai/ns/acme/sa/worker"),
+            ("DNS", "worker-1.acme.zakuro.local"),
+        ),
+    }
+    ident = extract_peer_from_request(_StubRequest(tls_obj=_StubSSLObject(cert)))
+    assert ident.subject_cn == "tenant-acme/worker-1"
+    assert ident.spiffe_id == "spiffe://zakuro.ai/ns/acme/sa/worker"
+    assert ident.dns_sans == ("worker-1.acme.zakuro.local",)
+
+
+def test_extract_peer_falls_through_to_xfcc_header() -> None:
+    header = (
+        'Subject="CN=tenant-acme/worker-1";'
+        "URI=spiffe://zakuro.ai/ns/acme/sa/worker;"
+        "DNS=worker-1.acme.zakuro.local"
+    )
+    ident = extract_peer_from_request(_StubRequest(headers={"x-forwarded-client-cert": header}))
+    assert ident.subject_cn == "tenant-acme/worker-1"
+    assert ident.spiffe_id == "spiffe://zakuro.ai/ns/acme/sa/worker"
+    assert "worker-1.acme.zakuro.local" in ident.dns_sans
+
+
+def test_extract_peer_returns_anonymous_when_no_material() -> None:
+    ident = extract_peer_from_request(_StubRequest())
+    assert ident.is_anonymous
+
+
+def test_parse_xfcc_takes_first_entry_only() -> None:
+    # Two entries — direct peer first, chain ancestor second
+    header = 'Subject="CN=direct-peer";URI=spiffe://zakuro.ai/ns/a/sa/w,Subject="CN=ca-cert"'
+    ident = parse_x_forwarded_client_cert(header)
+    assert ident.subject_cn == "direct-peer"
+
+
+def test_parse_xfcc_ignores_non_spiffe_uris() -> None:
+    header = 'Subject="CN=peer";URI=https://example.com'
+    ident = parse_x_forwarded_client_cert(header)
+    assert ident.spiffe_id is None
+
+
+def test_peer_identity_is_anonymous() -> None:
+    anon = PeerIdentity(subject_cn=None, spiffe_id=None, dns_sans=())
+    named = PeerIdentity(subject_cn="cn", spiffe_id=None, dns_sans=())
+    spiffe = PeerIdentity(subject_cn=None, spiffe_id="spiffe://", dns_sans=())
+    assert anon.is_anonymous
+    assert not named.is_anonymous
+    assert not spiffe.is_anonymous

--- a/tests/transport/test_tls.py
+++ b/tests/transport/test_tls.py
@@ -1,0 +1,117 @@
+"""Unit tests for the mTLS transport substrate (#115, RFC 0002)."""
+
+from __future__ import annotations
+
+import ssl
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
+
+from zakuro.transport import (
+    TlsNotConfiguredError,
+    build_aioquic_server_configuration,
+    build_httpx_client,
+    load_client_tls,
+    load_server_tls,
+)
+from zakuro.transport.tls import build_client_ssl_context, build_server_ssl_context
+
+
+def _write_cert(cert_dir: Path, *, common_name: str) -> None:
+    cert_dir.mkdir(parents=True, exist_ok=True)
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    now = datetime.now(timezone.utc)
+    subject = issuer = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, common_name)])
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(issuer)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - timedelta(minutes=1))
+        .not_valid_after(now + timedelta(hours=1))
+        .sign(key, hashes.SHA256())
+    )
+    (cert_dir / "tls.crt").write_bytes(cert.public_bytes(serialization.Encoding.PEM))
+    (cert_dir / "tls.key").write_bytes(
+        key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+    )
+    (cert_dir / "ca.crt").write_bytes(cert.public_bytes(serialization.Encoding.PEM))
+
+
+@pytest.fixture
+def cert_dir(tmp_path: Path) -> Path:
+    target = tmp_path / "certs"
+    _write_cert(target, common_name="zakuro-worker-test")
+    return target
+
+
+def test_load_server_tls_raises_when_env_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ZAKURO_CERT_DIR", raising=False)
+    with pytest.raises(TlsNotConfiguredError):
+        load_server_tls()
+
+
+def test_load_server_tls_raises_when_file_missing(tmp_path: Path) -> None:
+    with pytest.raises(TlsNotConfiguredError):
+        load_server_tls(cert_dir=str(tmp_path))
+
+
+def test_load_server_tls_happy_path(cert_dir: Path) -> None:
+    material = load_server_tls(cert_dir=str(cert_dir))
+    assert material.cert_path == cert_dir / "tls.crt"
+    assert material.key_path == cert_dir / "tls.key"
+    assert material.ca_bundle_path == cert_dir / "ca.crt"
+
+
+def test_load_server_tls_respects_env(monkeypatch: pytest.MonkeyPatch, cert_dir: Path) -> None:
+    monkeypatch.setenv("ZAKURO_CERT_DIR", str(cert_dir))
+    material = load_server_tls()
+    assert material.cert_path == cert_dir / "tls.crt"
+
+
+def test_load_client_tls_is_symmetric(cert_dir: Path) -> None:
+    a = load_server_tls(cert_dir=str(cert_dir))
+    b = load_client_tls(cert_dir=str(cert_dir))
+    assert a == b
+
+
+def test_build_server_ssl_context_requires_peer_cert(cert_dir: Path) -> None:
+    material = load_server_tls(cert_dir=str(cert_dir))
+    ctx = build_server_ssl_context(material)
+    assert ctx.verify_mode == ssl.CERT_REQUIRED
+    assert ctx.minimum_version == ssl.TLSVersion.TLSv1_3
+    assert ctx.check_hostname is False
+
+
+def test_build_client_ssl_context_requires_peer_cert(cert_dir: Path) -> None:
+    material = load_client_tls(cert_dir=str(cert_dir))
+    ctx = build_client_ssl_context(material)
+    assert ctx.verify_mode == ssl.CERT_REQUIRED
+    assert ctx.minimum_version == ssl.TLSVersion.TLSv1_3
+
+
+def test_build_aioquic_server_configuration(cert_dir: Path) -> None:
+    pytest.importorskip("aioquic")
+    material = load_server_tls(cert_dir=str(cert_dir))
+    config = build_aioquic_server_configuration(material)
+    assert config.is_client is False
+    assert "zk-worker-v2" in config.alpn_protocols
+    assert config.verify_mode == ssl.CERT_REQUIRED
+
+
+def test_build_httpx_client(cert_dir: Path) -> None:
+    material = load_client_tls(cert_dir=str(cert_dir))
+    client = build_httpx_client(material, base_url="https://example.test")
+    # httpx accepts an SSLContext via `verify`
+    assert client is not None
+    client.close()

--- a/zakuro/transport/__init__.py
+++ b/zakuro/transport/__init__.py
@@ -1,0 +1,49 @@
+"""mTLS transport surface for Zakuro (#115, RFC 0002).
+
+This package handles certificate loading + peer-identity extraction
+for both ends of every transport (QUIC and HTTP). It is the substrate
+on which the per-request JWT layer (:mod:`zakuro.auth`) builds:
+
+  - mTLS authenticates the *peer* (cert subject = SPIFFE-style ID);
+  - JWT authenticates the *request* (per-tenant scope).
+
+When the env var ``ZAKURO_CERT_DIR`` is unset, the loaders return
+``None`` so the worker still runs without TLS in dev — but
+:func:`load_server_tls_context` warns and the integration tests
+expect mTLS in CI.
+
+Forthcoming work
+----------------
+
+- Phase 2 PR wires the contexts into ``zakuro.worker.server`` (uvicorn
+  SSL args), ``zakuro.worker.quic_server`` (aioquic QuicConfiguration),
+  and the client's :class:`zakuro.client.ZakuroClient` (httpx + aioquic).
+- Once cert rotation under load is verified, the gossip-handshake (RFC
+  0008) re-issuance path lands as a third PR.
+"""
+
+from zakuro.transport.peer import (
+    PeerIdentity,
+    extract_peer_from_request,
+    parse_x_forwarded_client_cert,
+)
+from zakuro.transport.tls import (
+    TlsMaterial,
+    TlsNotConfiguredError,
+    build_aioquic_server_configuration,
+    build_httpx_client,
+    load_client_tls,
+    load_server_tls,
+)
+
+__all__ = [
+    "PeerIdentity",
+    "TlsMaterial",
+    "TlsNotConfiguredError",
+    "build_aioquic_server_configuration",
+    "build_httpx_client",
+    "extract_peer_from_request",
+    "load_client_tls",
+    "load_server_tls",
+    "parse_x_forwarded_client_cert",
+]

--- a/zakuro/transport/peer.py
+++ b/zakuro/transport/peer.py
@@ -1,0 +1,129 @@
+"""Peer-identity extraction for incoming requests (#115, RFC 0002).
+
+Once mTLS terminates at the worker (or at an ingress in front of it),
+the *peer* identity is carried by the X.509 client cert. This module
+extracts that identity into a typed :class:`PeerIdentity` so the auth
+middleware can refuse a cert from the wrong namespace before reading
+any request body.
+
+Supported transports
+--------------------
+
+1. **Direct mTLS** (uvicorn terminates TLS) — the peer cert lands in
+   ``request.scope["extensions"]["tls.transport"]`` as an
+   :class:`ssl.SSLObject` and we read it via
+   :func:`extract_peer_from_request`.
+2. **Ingress + X-Forwarded-Client-Cert** (RFC 9440) — the ingress
+   forwards the verified cert as a header. We parse it via
+   :func:`parse_x_forwarded_client_cert`.
+
+Both paths return a :class:`PeerIdentity`; callers should not have
+to know which transport produced it.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any
+
+_XFCC_PAIR_RE = re.compile(r'(\w+)=("([^"\\]|\\.)*"|[^;,]*)')
+
+
+@dataclass(frozen=True)
+class PeerIdentity:
+    """Validated peer identity extracted from an inbound mTLS connection."""
+
+    subject_cn: str | None
+    """The client cert's CommonName, when present."""
+    spiffe_id: str | None
+    """The first SPIFFE-format URI SAN (``spiffe://…``), when present."""
+    dns_sans: tuple[str, ...]
+    """Any DNS SANs on the cert. Order preserved."""
+
+    @property
+    def is_anonymous(self) -> bool:
+        """True iff no cert material was extracted."""
+        return self.subject_cn is None and self.spiffe_id is None and not self.dns_sans
+
+
+_ANONYMOUS = PeerIdentity(subject_cn=None, spiffe_id=None, dns_sans=())
+
+
+def _from_ssl_object(obj: Any) -> PeerIdentity:
+    """Extract a :class:`PeerIdentity` from an :class:`ssl.SSLObject`-like object.
+
+    Accepts any object exposing ``getpeercert(binary_form=False)`` and
+    ``getpeercert()`` returning the stdlib's parsed-cert dict.
+    """
+    try:
+        cert = obj.getpeercert()
+    except (ValueError, AttributeError):
+        return _ANONYMOUS
+    if not cert:
+        return _ANONYMOUS
+    subject_cn: str | None = None
+    for rdn in cert.get("subject", ()):  # tuple of tuples
+        for key, value in rdn:
+            if key == "commonName":
+                subject_cn = value
+                break
+    spiffe_id: str | None = None
+    dns_sans: list[str] = []
+    for kind, value in cert.get("subjectAltName", ()):
+        if kind.lower() == "uri" and value.startswith("spiffe://"):
+            spiffe_id = spiffe_id or value
+        elif kind.lower() == "dns":
+            dns_sans.append(value)
+    return PeerIdentity(subject_cn=subject_cn, spiffe_id=spiffe_id, dns_sans=tuple(dns_sans))
+
+
+def extract_peer_from_request(request: Any) -> PeerIdentity:
+    """Extract the peer identity from a Starlette/FastAPI request.
+
+    Tries direct-mTLS first (``scope["extensions"]["tls.transport"]``),
+    falls back to the ``X-Forwarded-Client-Cert`` header (RFC 9440)
+    when behind an ingress. Returns an anonymous identity if neither
+    path produces material — the caller decides whether to refuse.
+    """
+    scope = getattr(request, "scope", None) or {}
+    tls_obj = (scope.get("extensions") or {}).get("tls.transport")
+    if tls_obj is not None:
+        ident = _from_ssl_object(tls_obj)
+        if not ident.is_anonymous:
+            return ident
+    header = request.headers.get("x-forwarded-client-cert", "")
+    if header:
+        return parse_x_forwarded_client_cert(header)
+    return _ANONYMOUS
+
+
+def parse_x_forwarded_client_cert(value: str) -> PeerIdentity:
+    """Parse an RFC 9440 ``X-Forwarded-Client-Cert`` header value.
+
+    The header carries one or more comma-separated cert entries, each a
+    semicolon-separated list of key=value pairs (``Subject``, ``URI``,
+    ``DNS``, ``Hash`` etc.). We honour the first entry only — RFC 9440
+    states the first cert is the *direct* peer; subsequent entries are
+    chain ancestors.
+    """
+    first_entry = value.split(",", 1)[0]
+    subject_cn: str | None = None
+    spiffe_id: str | None = None
+    dns_sans: list[str] = []
+    for match in _XFCC_PAIR_RE.finditer(first_entry):
+        key = match.group(1)
+        raw_value = match.group(2)
+        # Strip enclosing double quotes when present
+        if raw_value.startswith('"') and raw_value.endswith('"'):
+            raw_value = raw_value[1:-1].replace('\\"', '"')
+        lk = key.lower()
+        if lk == "subject":
+            for cn_match in re.finditer(r"CN=([^,]+)", raw_value):
+                subject_cn = cn_match.group(1).strip()
+                break
+        elif lk == "uri" and raw_value.startswith("spiffe://"):
+            spiffe_id = spiffe_id or raw_value.strip()
+        elif lk == "dns":
+            dns_sans.append(raw_value.strip())
+    return PeerIdentity(subject_cn=subject_cn, spiffe_id=spiffe_id, dns_sans=tuple(dns_sans))

--- a/zakuro/transport/tls.py
+++ b/zakuro/transport/tls.py
@@ -1,0 +1,162 @@
+"""TLS material loading + transport-config builders (#115, RFC 0002).
+
+The worker and client both load their mTLS material from a single
+directory, conventionally ``~/.zakuro/certs/`` (override with
+``ZAKURO_CERT_DIR``). Files expected:
+
+  - ``tls.crt`` — this end's certificate (PEM)
+  - ``tls.key`` — this end's private key (PEM, unencrypted)
+  - ``ca.crt`` — bundle of CAs to verify the *peer* against (PEM,
+    may contain multiple roots concatenated)
+
+Missing files raise :class:`TlsNotConfiguredError` rather than
+silently degrading to plaintext — a worker that thinks it's running
+mTLS but isn't is a foot-gun we deliberately refuse.
+
+The :func:`build_*` helpers turn :class:`TlsMaterial` into the
+flavour-specific config objects each transport needs (uvicorn's SSL
+args, aioquic's ``QuicConfiguration``, httpx's ``verify`` / ``cert``).
+"""
+
+from __future__ import annotations
+
+import os
+import ssl
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+class TlsNotConfiguredError(Exception):
+    """Raised when an mTLS load is requested but the material is missing.
+
+    Catch this at the worker / client entry point and either:
+
+      - refuse to start (``ZAKURO_TLS_REQUIRED=1``), or
+      - log a clear warning and fall through to a plaintext socket
+        (dev only — never default to this in production).
+    """
+
+
+@dataclass(frozen=True)
+class TlsMaterial:
+    """Loaded mTLS files. Use :func:`load_server_tls` / :func:`load_client_tls`."""
+
+    cert_path: Path
+    key_path: Path
+    ca_bundle_path: Path
+
+
+def _resolve_cert_dir(explicit: str | None = None) -> Path:
+    raw = explicit or os.environ.get("ZAKURO_CERT_DIR", "").strip()
+    if not raw:
+        raise TlsNotConfiguredError(
+            "ZAKURO_CERT_DIR is unset. Set it to the directory containing "
+            "tls.crt / tls.key / ca.crt before starting the worker."
+        )
+    return Path(raw).expanduser()
+
+
+def _check_file(path: Path, role: str) -> Path:
+    if not path.is_file():
+        raise TlsNotConfiguredError(f"{role} file missing or not a regular file: {path}")
+    return path
+
+
+def _load(cert_dir: str | None) -> TlsMaterial:
+    base = _resolve_cert_dir(cert_dir)
+    return TlsMaterial(
+        cert_path=_check_file(base / "tls.crt", "tls.crt"),
+        key_path=_check_file(base / "tls.key", "tls.key"),
+        ca_bundle_path=_check_file(base / "ca.crt", "ca.crt"),
+    )
+
+
+def load_server_tls(cert_dir: str | None = None) -> TlsMaterial:
+    """Load the server-side mTLS files for the worker.
+
+    Raises :class:`TlsNotConfiguredError` if any file is missing.
+    """
+    return _load(cert_dir)
+
+
+def load_client_tls(cert_dir: str | None = None) -> TlsMaterial:
+    """Load the client-side mTLS files for the ZakuroClient.
+
+    Same files as :func:`load_server_tls` — the symmetry is intentional;
+    each side is both *a* server (responds) and *a* client (dispatches),
+    and they share the same per-mesh CA. Separate function names for
+    grep-friendliness.
+    """
+    return _load(cert_dir)
+
+
+# ---- transport-specific builders --------------------------------------------
+
+
+def build_server_ssl_context(material: TlsMaterial) -> ssl.SSLContext:
+    """Return an ``SSLContext`` configured for mTLS server use.
+
+    - TLS 1.3 (PROTOCOL_TLS_SERVER)
+    - Loads the server cert + key
+    - Requires + verifies the peer cert against the CA bundle
+    - Disables session tickets / TLS 1.2 compat (RFC 0002 §"transport")
+    """
+    ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    ctx.minimum_version = ssl.TLSVersion.TLSv1_3
+    ctx.load_cert_chain(certfile=str(material.cert_path), keyfile=str(material.key_path))
+    ctx.load_verify_locations(cafile=str(material.ca_bundle_path))
+    ctx.verify_mode = ssl.CERT_REQUIRED
+    ctx.check_hostname = False  # we verify by SPIFFE-style SAN ourselves
+    return ctx
+
+
+def build_client_ssl_context(material: TlsMaterial) -> ssl.SSLContext:
+    """Return an ``SSLContext`` configured for mTLS client use."""
+    ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    ctx.minimum_version = ssl.TLSVersion.TLSv1_3
+    ctx.load_cert_chain(certfile=str(material.cert_path), keyfile=str(material.key_path))
+    ctx.load_verify_locations(cafile=str(material.ca_bundle_path))
+    ctx.verify_mode = ssl.CERT_REQUIRED
+    ctx.check_hostname = False  # SPIFFE-style SAN verification handled in app
+    return ctx
+
+
+def build_httpx_client(material: TlsMaterial, *, base_url: str | None = None) -> Any:
+    """Return an ``httpx.Client`` configured for mTLS.
+
+    Passed as ``verify=<CA bundle>`` + ``cert=(cert, key)``. httpx
+    accepts paths or already-loaded SSLContexts; we go with the
+    pre-built context so both sides share the exact same settings.
+    """
+    import httpx
+
+    ctx = build_client_ssl_context(material)
+    kwargs: dict[str, Any] = {"verify": ctx}
+    if base_url is not None:
+        kwargs["base_url"] = base_url
+    return httpx.Client(**kwargs)
+
+
+def build_aioquic_server_configuration(material: TlsMaterial, *, alpn: str = "zk-worker-v2") -> Any:
+    """Return an aioquic ``QuicConfiguration`` configured for mTLS server use.
+
+    ALPN bump to ``zk-worker-v2`` matches the wire-format bump in RFC 0001
+    (so v0.3 clients can't accidentally talk to a v0.4 worker).
+    """
+    try:
+        from aioquic.quic.configuration import QuicConfiguration
+    except ImportError as exc:  # pragma: no cover
+        raise ImportError("QUIC support requires the [worker] extra (aioquic).") from exc
+
+    config = QuicConfiguration(
+        is_client=False,
+        alpn_protocols=[alpn],
+        verify_mode=ssl.CERT_REQUIRED,
+    )
+    config.load_cert_chain(
+        certfile=str(material.cert_path),
+        keyfile=str(material.key_path),
+    )
+    config.load_verify_locations(cafile=str(material.ca_bundle_path))
+    return config


### PR DESCRIPTION
## Summary

Closes #115 **Phase 1**. Phase 2 wires the contexts into the worker / client / QUIC transports and lands separately.

- `zakuro/transport/tls.py`
  - `load_server_tls()` / `load_client_tls()` read `tls.crt` + `tls.key` + `ca.crt` from `ZAKURO_CERT_DIR`. `TlsNotConfiguredError` on missing material (fail closed).
  - `build_server_ssl_context` / `build_client_ssl_context` — TLS 1.3 min, `CERT_REQUIRED`, hostname checking off (SPIFFE-style SAN verified in app).
  - `build_aioquic_server_configuration` — ALPN `zk-worker-v2` per the RFC 0001 wire-format bump.
  - `build_httpx_client` — pre-built SSLContext so every transport shares the exact same settings.
- `zakuro/transport/peer.py`
  - `extract_peer_from_request(req)` tries direct-mTLS, falls back to RFC 9440 `X-Forwarded-Client-Cert`.
  - `PeerIdentity` carries `subject_cn` / `spiffe_id` / `dns_sans` + `is_anonymous`.
- `tests/transport/` — 15 tests with self-signed certs minted via `cryptography.x509`.

## Test plan

- [x] `pytest tests/transport/` → 15 passed.
- [x] Full suite: 185 passed.
- [x] `ruff check` / `ruff format --check` clean.
- [x] `mypy zakuro/transport/` clean.
- [ ] CI runs green.

## Phase 2 — what's next

One-liner replacements at each call site:
- `zakuro.worker.server` → uvicorn ssl args.
- `zakuro.worker.quic_server` → `build_aioquic_server_configuration`.
- `zakuro.client.ZakuroClient` → `build_httpx_client`.

## Cross-repo

Paired zc PR needed in Phase 2: zc's `QuicConfiguration` must require client certs against the same per-mesh CA. Will reference `zc#NN` from the wiring PR.