### PR TITLE
feat(observability): SLOs + burn-rate alerts + Grafana overview (#127, #129)

### DIFF
--- a/docs/observability/slos.md
+++ b/docs/observability/slos.md
@@ -1,0 +1,109 @@
+# SLOs and burn-rate alerts
+
+**Status:** Initial (2026-05). Maintainer: oncall@zakuro.ai. Refresh cadence: every release with measured-numbers data; threshold review quarterly.
+
+Closes [#127](https://github.com/zakuro-ai/zakuro/issues/127). Wires the Prometheus metrics from [PR #185 / #124](https://github.com/zakuro-ai/zakuro/pull/185) into a Service-Level Objective set and the burn-rate alerts that page oncall when an SLO is being eaten faster than the error budget allows.
+
+The Grafana dashboards that visualize these live alongside in `ops/grafana/zakuro-overview.json` (#129).
+
+## How to read this document
+
+- Every SLO row carries: an **Objective** (what we promise), an **SLI** (how we measure it), a **target** (the percentile we commit to), a **window** (over how long), and an **error budget** (how much we can fail in that window).
+- Burn-rate alerts use the **multi-window, multi-burn-rate** pattern from Google's SRE Workbook. Two windows per SLO (a fast 1-hour window for outages, a slow 6-hour window for slow drift) — both must fire to page. This trades a few minutes of detection latency for ~zero false positives during routine traffic blips.
+
+## SLO catalogue
+
+### SLO-1 — Dispatch latency
+
+**Objective:** 99% of successful dispatches complete within 250 ms server-side (worker `/execute` handler wall clock).
+
+| Field | Value |
+|---|---|
+| **SLI source** | `zakuro_dispatch_latency_seconds_bucket` histogram (#124) |
+| **Target** | 99.0% |
+| **Window** | 30 days rolling |
+| **Error budget** | 1.0% of dispatches |
+| **Indicator query** | `sum(rate(zakuro_dispatch_latency_seconds_bucket{le="0.25"}[5m])) / sum(rate(zakuro_dispatch_latency_seconds_count[5m]))` |
+
+**Why 250 ms / 99%?** Measured numbers from the runtime tracking board: laptop-only QUIC dispatch is ~150 ms p95 cold; cross-container dispatch is ~130 ms. Setting the SLO at 250 ms / 99% leaves enough headroom for two layers of network and a small queue at the broker while making cold-start regressions visible. Tighten to 150 ms once the dispatch path has 4 weeks of steady-state data at v0.4.
+
+### SLO-2 — Auth success rate
+
+**Objective:** ≥ 99.5% of requests that present a valid bearer token reach the handler (no false-401s).
+
+| Field | Value |
+|---|---|
+| **SLI source** | `zakuro_http_requests_total` (#124) + `zakuro_auth_failure_total` (#124 / #116) |
+| **Target** | 99.5% |
+| **Window** | 30 days rolling |
+| **Error budget** | 0.5% of authed requests |
+| **Indicator query** | `1 - (sum(rate(zakuro_auth_failure_total[5m])) / sum(rate(zakuro_http_requests_total[5m])))` |
+
+**Why 99.5%?** The auth code path is small and well-tested; expected false-positive rate is dominated by clock skew on JWT verification (`leeway_seconds=5` allows ~25 s window). 99.5% gives ~3.6 hours of degraded-auth budget per month, enough to absorb a single rotation that goes sideways without paging.
+
+### SLO-3 — Worker availability
+
+**Objective:** ≥ 99.9% of `GET /ready` probes return 200 within 2 seconds, per worker.
+
+| Field | Value |
+|---|---|
+| **SLI source** | `zakuro_http_requests_total{path="/ready"}` (#124) |
+| **Target** | 99.9% |
+| **Window** | 30 days rolling |
+| **Error budget** | 0.1% per worker per month — ~43 minutes |
+| **Indicator query** | `sum(rate(zakuro_http_requests_total{path="/ready",status=~"2.."}[5m])) / sum(rate(zakuro_http_requests_total{path="/ready"}[5m]))` |
+
+**Why per worker?** The mesh tolerates individual worker failures (RFC 0008 gossip auto-routes), so the *aggregate* availability is much higher than 99.9% as long as individual workers hold this. Per-worker SLO surfaces the slow-burning failure (an individual worker degrading) before the mesh has to compensate.
+
+### SLO-4 — Wire-format integrity
+
+**Objective:** Zero envelopes per million pass postcard decode but fail HMAC.
+
+| Field | Value |
+|---|---|
+| **SLI source** | `zakuro_auth_failure_total{reason="hmac"}` |
+| **Target** | < 0.0001% (effectively zero) |
+| **Window** | 7 days rolling |
+| **Error budget** | 0 — any non-zero HMAC failure rate is an incident |
+| **Indicator query** | `sum(increase(zakuro_auth_failure_total{reason="hmac"}[5m]))` |
+
+**Why a hard zero?** A non-zero rate means either (a) a misconfigured key on the broker side, (b) clock-related JWT issuance bugs leaking into the HMAC derivation, or (c) someone is trying to forge envelopes. None of those are "burn the budget for a while and decide later" — they page immediately.
+
+## Burn-rate alerts
+
+Following the SRE Workbook's multi-window multi-burn-rate pattern. For each non-zero-budget SLO we ship two alerts:
+
+| Alert | Trigger | Page severity |
+|---|---|---|
+| `<SLO>FastBurn` | Burn ≥ **14.4×** the steady-state error budget over the last **1 hour** AND over the last **5 minutes** | P1 page |
+| `<SLO>SlowBurn` | Burn ≥ **6×** the steady-state error budget over the last **6 hours** AND over the last **30 minutes** | P2 ticket |
+
+Burn rate of 1× = consuming the monthly budget exactly across the month. 14.4× consumes it in 2 hours; 6× consumes it in 5 days. The "AND" condition across two windows is the false-positive suppressor.
+
+SLO-4 (wire-format integrity) gets a single hard-fire rule: any non-zero count over 5 minutes pages immediately.
+
+The Prometheus rule file lives at [`ops/alerts/zakuro-slos.yml`](https://github.com/zakuro-ai/zakuro/blob/master/ops/alerts/zakuro-slos.yml).
+
+## Error-budget policy
+
+When an SLO has consumed > 50% of its budget for the current window:
+
+1. **Freeze risky merges.** The CI lane that publishes a release runs `python ops/check_slo_freeze.py` (forthcoming — issue tracked in [#127](https://github.com/zakuro-ai/zakuro/issues/127)) and fails if any SLO is over 50%. Override requires a maintainer note in the PR.
+2. **Page-out blast radius decisions go to oncall.** No "we'll just ship it; the budget will recover" without an explicit oncall sign-off.
+
+When an SLO has *exhausted* its budget (≥ 100% consumed) before window rollover:
+
+1. **All deploys halted** except security/SLO-fix patches.
+2. **Post-mortem within 5 business days** with the SLO-recovery plan (or a documented decision to lower the SLO).
+
+## Process
+
+- Every release reviews the past-window SLO consumption and either keeps the target, raises it (we got lucky), or lowers it (it was unrealistic). The decision lands in the release-notes header.
+- New SLOs are proposed via RFC, not as PRs to this file directly — the discussion of "is this the right thing to commit to" deserves its own RFC.
+
+## References
+
+- [Google SRE Workbook — Alerting on SLOs](https://sre.google/workbook/alerting-on-slos/)
+- [Prometheus best practices — recording rules](https://prometheus.io/docs/practices/rules/)
+- [`docs/ci.md`](https://github.com/zakuro-ai/zakuro/blob/master/docs/ci.md) — CI lane required-vs-advisory; deploy freeze interacts with this
+- [`docs/security/threat-model.md`](https://github.com/zakuro-ai/zakuro/blob/master/docs/security/threat-model.md) §6 — SLO-4 ties to the wire-format gate

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -88,6 +88,8 @@ nav:
       - Wire protocol: PROTOCOL.md
   - Guides:
       - Getting started: getting-started.md
+  - Operations:
+      - SLOs and burn-rate alerts: observability/slos.md
   - Security:
       - Verifying releases: security/verifying-releases.md
       - Threat model: security/threat-model.md

--- a/ops/alerts/zakuro-slos.yml
+++ b/ops/alerts/zakuro-slos.yml
@@ -1,0 +1,254 @@
+# Prometheus alerting + recording rules for Zakuro SLOs (#127, RFC 0003).
+#
+# Load with:
+#   prometheus --config.file=prometheus.yml --rule-files=ops/alerts/zakuro-slos.yml
+#
+# Each alert pairs a "fast burn" (P1 page) with a "slow burn" (P2 ticket).
+# Both must fire across their two configured windows to suppress flapping —
+# see docs/observability/slos.md for the methodology.
+
+groups:
+  # ---------------------------------------------------------------------------
+  # Recording rules — pre-aggregate the SLIs so alert expressions stay readable
+  # and PromQL doesn't re-compute the same sum() on every evaluation.
+  # ---------------------------------------------------------------------------
+  - name: zakuro_slo_recording_rules
+    interval: 30s
+    rules:
+      - record: zakuro:dispatch_latency:p99_5m
+        expr: |
+          histogram_quantile(
+            0.99,
+            sum by (le) (rate(zakuro_dispatch_latency_seconds_bucket[5m]))
+          )
+
+      - record: zakuro:dispatch_latency_slow_ratio_5m
+        expr: |
+          1 - (
+            sum(rate(zakuro_dispatch_latency_seconds_bucket{le="0.25"}[5m]))
+            /
+            sum(rate(zakuro_dispatch_latency_seconds_count[5m]))
+          )
+
+      - record: zakuro:dispatch_latency_slow_ratio_1h
+        expr: |
+          1 - (
+            sum(rate(zakuro_dispatch_latency_seconds_bucket{le="0.25"}[1h]))
+            /
+            sum(rate(zakuro_dispatch_latency_seconds_count[1h]))
+          )
+
+      - record: zakuro:dispatch_latency_slow_ratio_6h
+        expr: |
+          1 - (
+            sum(rate(zakuro_dispatch_latency_seconds_bucket{le="0.25"}[6h]))
+            /
+            sum(rate(zakuro_dispatch_latency_seconds_count[6h]))
+          )
+
+      - record: zakuro:auth_failure_ratio_5m
+        expr: |
+          sum(rate(zakuro_auth_failure_total[5m]))
+          /
+          clamp_min(sum(rate(zakuro_http_requests_total[5m])), 1)
+
+      - record: zakuro:auth_failure_ratio_1h
+        expr: |
+          sum(rate(zakuro_auth_failure_total[1h]))
+          /
+          clamp_min(sum(rate(zakuro_http_requests_total[1h])), 1)
+
+      - record: zakuro:auth_failure_ratio_6h
+        expr: |
+          sum(rate(zakuro_auth_failure_total[6h]))
+          /
+          clamp_min(sum(rate(zakuro_http_requests_total[6h])), 1)
+
+      - record: zakuro:ready_failure_ratio_5m
+        expr: |
+          sum by (worker_id) (rate(zakuro_http_requests_total{path="/ready",status!~"2.."}[5m]))
+          /
+          clamp_min(
+            sum by (worker_id) (rate(zakuro_http_requests_total{path="/ready"}[5m])),
+            1
+          )
+
+      - record: zakuro:ready_failure_ratio_1h
+        expr: |
+          sum by (worker_id) (rate(zakuro_http_requests_total{path="/ready",status!~"2.."}[1h]))
+          /
+          clamp_min(
+            sum by (worker_id) (rate(zakuro_http_requests_total{path="/ready"}[1h])),
+            1
+          )
+
+      - record: zakuro:ready_failure_ratio_6h
+        expr: |
+          sum by (worker_id) (rate(zakuro_http_requests_total{path="/ready",status!~"2.."}[6h]))
+          /
+          clamp_min(
+            sum by (worker_id) (rate(zakuro_http_requests_total{path="/ready"}[6h])),
+            1
+          )
+
+  # ---------------------------------------------------------------------------
+  # SLO-1 — Dispatch latency: 99% under 250ms over 30d (budget 1.0%)
+  # ---------------------------------------------------------------------------
+  - name: zakuro_slo1_dispatch_latency
+    rules:
+      - alert: ZakuroDispatchLatencyFastBurn
+        # 14.4× budget burn ⇒ fail-fraction > 14.4% over 1h (windowed at 5m + 1h)
+        expr: |
+          (
+            zakuro:dispatch_latency_slow_ratio_5m > (14.4 * 0.01)
+            and
+            zakuro:dispatch_latency_slow_ratio_1h > (14.4 * 0.01)
+          )
+        for: 2m
+        labels:
+          severity: page
+          slo: dispatch_latency
+          burn: fast
+        annotations:
+          summary: "Dispatch p99 latency budget burning fast (>14.4×)"
+          description: |
+            Over the last hour, more than 14.4% of dispatches took longer than
+            250 ms — burning the 30-day error budget at 14.4×. At this rate
+            the entire monthly budget (1%) goes in 2 hours. Pageable.
+            Runbook: docs/observability/slos.md#slo-1
+          dashboard: "{{ $externalURL }}/d/zakuro-overview/zakuro-overview?viewPanel=2"
+
+      - alert: ZakuroDispatchLatencySlowBurn
+        # 6× budget burn over 6h (windowed at 30m + 6h)
+        expr: |
+          (
+            zakuro:dispatch_latency_slow_ratio_6h > (6 * 0.01)
+            and
+            avg_over_time(zakuro:dispatch_latency_slow_ratio_5m[30m]) > (6 * 0.01)
+          )
+        for: 15m
+        labels:
+          severity: ticket
+          slo: dispatch_latency
+          burn: slow
+        annotations:
+          summary: "Dispatch latency drifting (6× burn over 6h)"
+          description: |
+            Sustained dispatch slowdown over the last 6 hours — burning the
+            30-day budget at 6×. Not pageable; investigate within 1 business day.
+            Runbook: docs/observability/slos.md#slo-1
+
+  # ---------------------------------------------------------------------------
+  # SLO-2 — Auth success rate: ≥ 99.5% over 30d (budget 0.5%)
+  # ---------------------------------------------------------------------------
+  - name: zakuro_slo2_auth_success
+    rules:
+      - alert: ZakuroAuthFailureFastBurn
+        expr: |
+          (
+            zakuro:auth_failure_ratio_5m > (14.4 * 0.005)
+            and
+            zakuro:auth_failure_ratio_1h > (14.4 * 0.005)
+          )
+        for: 2m
+        labels:
+          severity: page
+          slo: auth_success
+          burn: fast
+        annotations:
+          summary: "Auth failure rate burning fast (>7.2% of authed requests failing)"
+          description: |
+            Likely candidates: (a) JWT public key rotation went sideways,
+            (b) clock skew on the worker host exceeded leeway, (c) ongoing
+            brute-force / scope-confusion attack.
+            Runbook: docs/observability/slos.md#slo-2
+
+      - alert: ZakuroAuthFailureSlowBurn
+        expr: |
+          (
+            zakuro:auth_failure_ratio_6h > (6 * 0.005)
+            and
+            avg_over_time(zakuro:auth_failure_ratio_5m[30m]) > (6 * 0.005)
+          )
+        for: 15m
+        labels:
+          severity: ticket
+          slo: auth_success
+          burn: slow
+        annotations:
+          summary: "Auth failure rate drifting (6× burn over 6h)"
+          description: |
+            Sustained auth-failure elevation. Often surfaces a slow clock-skew
+            issue on a single worker, or a bad-token campaign that's hitting
+            real users via shared infra.
+            Runbook: docs/observability/slos.md#slo-2
+
+  # ---------------------------------------------------------------------------
+  # SLO-3 — Worker availability: ≥ 99.9% over 30d (budget 0.1%), per worker
+  # ---------------------------------------------------------------------------
+  - name: zakuro_slo3_worker_availability
+    rules:
+      - alert: ZakuroWorkerReadyFastBurn
+        expr: |
+          (
+            zakuro:ready_failure_ratio_5m > (14.4 * 0.001)
+            and
+            zakuro:ready_failure_ratio_1h > (14.4 * 0.001)
+          )
+        for: 2m
+        labels:
+          severity: page
+          slo: worker_availability
+          burn: fast
+        annotations:
+          summary: "Worker {{ $labels.worker_id }} readiness budget burning fast"
+          description: |
+            More than 1.44% of /ready probes failing on this worker over the
+            past hour. The mesh will be routing around this worker
+            (RFC 0008); investigate the host before the slow burn paints
+            a fleet-wide pattern.
+            Runbook: docs/observability/slos.md#slo-3
+
+      - alert: ZakuroWorkerReadySlowBurn
+        expr: |
+          (
+            zakuro:ready_failure_ratio_6h > (6 * 0.001)
+            and
+            avg_over_time(zakuro:ready_failure_ratio_5m[30m]) > (6 * 0.001)
+          )
+        for: 30m
+        labels:
+          severity: ticket
+          slo: worker_availability
+          burn: slow
+        annotations:
+          summary: "Worker {{ $labels.worker_id }} readiness drifting (6× burn)"
+          description: |
+            Sustained readiness drift. Single-worker degradation; the mesh
+            absorbs but capacity headroom is shrinking.
+            Runbook: docs/observability/slos.md#slo-3
+
+  # ---------------------------------------------------------------------------
+  # SLO-4 — Wire-format integrity: zero HMAC failures (budget 0)
+  # ---------------------------------------------------------------------------
+  - name: zakuro_slo4_wire_integrity
+    rules:
+      - alert: ZakuroHmacFailureDetected
+        # Any non-zero rate of HMAC failures over 5 minutes pages immediately.
+        expr: |
+          sum(increase(zakuro_auth_failure_total{reason="hmac"}[5m])) > 0
+        for: 0m
+        labels:
+          severity: page
+          slo: wire_integrity
+        annotations:
+          summary: "Wire-format HMAC failure detected — investigate immediately"
+          description: |
+            One or more envelopes decoded successfully but failed HMAC
+            verification in the last 5 minutes. Candidates:
+              (a) misconfigured per-tenant key on the broker
+                  (HKDF derivation diverged from worker),
+              (b) clock-related JWT issuance bug leaking into HMAC key,
+              (c) envelope forgery attempt.
+            Page on, do not silence without a root cause.
+            Runbook: docs/observability/slos.md#slo-4

--- a/ops/grafana/README.md
+++ b/ops/grafana/README.md
@@ -1,0 +1,51 @@
+# Zakuro Grafana dashboards
+
+This directory is the source-of-truth for every dashboard the Zakuro project ships. Edit JSON here, not in the Grafana UI — UI edits are lossy across deploys.
+
+Closes [#129](https://github.com/zakuro-ai/zakuro/issues/129).
+
+## Loading a dashboard
+
+```bash
+# Provisioning path (recommended) — Grafana loads dashboards from a
+# directory at startup. Drop the JSONs into your Grafana's
+# /etc/grafana/provisioning/dashboards/ path or equivalent.
+cp ops/grafana/*.json /etc/grafana/provisioning/dashboards/
+
+# Or load via the HTTP API:
+curl -X POST "$GRAFANA_URL/api/dashboards/db" \
+    -H "Authorization: Bearer $GRAFANA_API_KEY" \
+    -H "Content-Type: application/json" \
+    -d @ops/grafana/zakuro-overview.json
+```
+
+The dashboards expect a Prometheus datasource named `${DS_PROMETHEUS}`. Configure that in your Grafana before importing.
+
+## Dashboard catalogue
+
+| File | Title | What it shows |
+|---|---|---|
+| `zakuro-overview.json` | Zakuro — runtime overview | All four SLO panels (dispatch latency p99, auth-success rate, HMAC failures, per-worker readiness) + supporting metrics (request rate, queue depth, error rate, auth-fail reasons). |
+
+The SLO targets visualised here are defined in [`docs/observability/slos.md`](../../docs/observability/slos.md). Burn-rate alert thresholds match the rules in [`ops/alerts/zakuro-slos.yml`](../alerts/zakuro-slos.yml).
+
+## Template variables
+
+Every panel respects two filters:
+
+- **Worker** — `worker_id` label. `All` aggregates the fleet; pick one worker to drill down.
+- **Tenant** — `tenant_id` label. `All` aggregates tenants; pick one to investigate a customer-specific slowdown.
+
+## Annotations
+
+Deploys appear as vertical lines, derived from `changes(zakuro_http_requests_total{path="/info"}[5m]) > 0` — `/info` is hit on every worker startup, so a spike there means a fresh start. Replace with a proper deploy-event metric when one exists.
+
+## How to add a dashboard
+
+1. Build the dashboard in a local Grafana (`docker run --rm -p 3000:3000 grafana/grafana`).
+2. Export via **Dashboard → Share → Export → Save to file**.
+3. Strip the auto-generated `__inputs` / `__requires` blocks and replace the datasource UID with `${DS_PROMETHEUS}`.
+4. Commit the JSON here + add a row to the catalogue.
+5. Update [`docs/observability/slos.md`](../../docs/observability/slos.md) if the dashboard introduces a new SLO panel.
+
+Lossy round-trips through Grafana's UI **drop annotations and template variables**. If you change those, edit the JSON directly.

--- a/ops/grafana/zakuro-overview.json
+++ b/ops/grafana/zakuro-overview.json
@@ -1,0 +1,249 @@
+{
+  "uid": "zakuro-overview",
+  "title": "Zakuro — runtime overview",
+  "description": "Runtime SLO + supporting-metric overview for the Zakuro worker fleet. Owners: oncall@zakuro.ai. Source-of-truth: ops/grafana/zakuro-overview.json on master — edit there, not in the Grafana UI.",
+  "tags": ["zakuro", "slo", "runtime"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "templating": {
+    "list": [
+      {
+        "name": "worker_id",
+        "label": "Worker",
+        "type": "query",
+        "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+        "query": {"query": "label_values(zakuro_worker_queue_depth, worker_id)", "refId": "Prom"},
+        "includeAll": true,
+        "multi": true,
+        "current": {"selected": false, "text": "All", "value": "$__all"}
+      },
+      {
+        "name": "tenant_id",
+        "label": "Tenant",
+        "type": "query",
+        "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+        "query": {"query": "label_values(zakuro_http_requests_total, tenant_id)", "refId": "Prom"},
+        "includeAll": true,
+        "multi": true,
+        "current": {"selected": false, "text": "All", "value": "$__all"}
+      }
+    ]
+  },
+  "annotations": {
+    "list": [
+      {
+        "name": "Deploys",
+        "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+        "enable": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "expr": "changes(zakuro_http_requests_total{path=\"/info\"}[5m]) > 0"
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "row",
+      "title": "SLOs",
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 0},
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "SLO-1 dispatch latency p99 (target: < 250 ms)",
+      "description": "Server-side dispatch latency 99th percentile, 5-minute rolling. Crossing 250 ms means SLO-1's error budget is burning.",
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 1},
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(zakuro_dispatch_latency_seconds_bucket{tenant_id=~\"$tenant_id\",worker_id=~\"$worker_id\"}[5m])))",
+          "legendFormat": "p99 latency"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "yellow", "value": 0.15},
+              {"color": "red", "value": 0.25}
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {"legend": {"showLegend": true}}
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "SLO-2 auth success rate (last 1h)",
+      "description": "Fraction of HTTP requests that did NOT fail auth. Target ≥ 99.5%.",
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "gridPos": {"h": 8, "w": 6, "x": 12, "y": 1},
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "1 - (sum(rate(zakuro_auth_failure_total[1h])) / clamp_min(sum(rate(zakuro_http_requests_total[1h])), 1))"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "decimals": 3,
+          "min": 0.99,
+          "max": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "red", "value": null},
+              {"color": "yellow", "value": 0.99},
+              {"color": "green", "value": 0.995}
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {"colorMode": "background", "graphMode": "area"}
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "SLO-4 HMAC failure count (5m)",
+      "description": "Wire-format integrity. ANY non-zero count is an incident.",
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "gridPos": {"h": 8, "w": 6, "x": 18, "y": 1},
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(increase(zakuro_auth_failure_total{reason=\"hmac\"}[5m]))"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "red", "value": 1}
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {"colorMode": "background"}
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "SLO-3 worker readiness fail-rate (per worker)",
+      "description": "1 - success rate of /ready probes per worker. Target ≤ 0.1%.",
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "gridPos": {"h": 8, "w": 24, "x": 0, "y": 9},
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (worker_id) (rate(zakuro_http_requests_total{path=\"/ready\",status!~\"2..\",worker_id=~\"$worker_id\"}[5m])) / clamp_min(sum by (worker_id) (rate(zakuro_http_requests_total{path=\"/ready\",worker_id=~\"$worker_id\"}[5m])), 1)",
+          "legendFormat": "{{worker_id}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "max": 0.05,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "yellow", "value": 0.001},
+              {"color": "red", "value": 0.0144}
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {"legend": {"showLegend": true, "placement": "right"}}
+    },
+    {
+      "id": 6,
+      "type": "row",
+      "title": "Supporting metrics",
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 17},
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 7,
+      "type": "timeseries",
+      "title": "Request rate (qps) by path",
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 18},
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (path) (rate(zakuro_http_requests_total{tenant_id=~\"$tenant_id\",worker_id=~\"$worker_id\"}[1m]))",
+          "legendFormat": "{{path}}"
+        }
+      ],
+      "fieldConfig": {"defaults": {"unit": "reqps"}, "overrides": []}
+    },
+    {
+      "id": 8,
+      "type": "timeseries",
+      "title": "Worker queue depth",
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 18},
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "zakuro_worker_queue_depth{worker_id=~\"$worker_id\"}",
+          "legendFormat": "{{worker_id}}"
+        }
+      ],
+      "fieldConfig": {"defaults": {"unit": "short"}, "overrides": []}
+    },
+    {
+      "id": 9,
+      "type": "timeseries",
+      "title": "HTTP errors by status",
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 26},
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (status) (rate(zakuro_http_requests_total{status!~\"2..\",worker_id=~\"$worker_id\"}[5m]))",
+          "legendFormat": "{{status}}"
+        }
+      ],
+      "fieldConfig": {"defaults": {"unit": "reqps"}, "overrides": []}
+    },
+    {
+      "id": 10,
+      "type": "timeseries",
+      "title": "Auth failures by reason",
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 26},
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (reason) (rate(zakuro_auth_failure_total{tenant_id=~\"$tenant_id\"}[5m]))",
+          "legendFormat": "{{reason}}"
+        }
+      ],
+      "fieldConfig": {"defaults": {"unit": "reqps"}, "overrides": []}
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Closes **#127** and **#129**. Closes the reliability-pillar P1 backlog on top of PR #185 (Prometheus metrics).

- `docs/observability/slos.md` — SLO-1..SLO-4 catalogue with measured-number-derived targets, error-budget policy, and the SRE Workbook's multi-window/multi-burn-rate pattern.
- `ops/alerts/zakuro-slos.yml` — Prometheus recording + alerting rules. Per SLO: `FastBurn` (P1 page, 14.4× budget, 5m+1h windows) and `SlowBurn` (P2 ticket, 6× budget, 30m+6h windows). SLO-4 (wire-format integrity) ships a single hard-fire rule — any non-zero HMAC failure rate pages.
- `ops/grafana/zakuro-overview.json` — 8-panel overview dashboard with template variables (worker, tenant), deploy annotations, and threshold colours that match the SLO targets.
- `ops/grafana/README.md` — load instructions + how-to-add-a-dashboard.
- `mkdocs.yml` — new "Operations" nav section with the SLO doc. `ops/` files are linked via absolute github.com URLs (they live outside the mkdocs docs/ root).

## Test plan

- [x] `python -c "import yaml; yaml.safe_load(open('ops/alerts/zakuro-slos.yml'))"` → ok.
- [x] `python -c "import json; json.load(open('ops/grafana/zakuro-overview.json'))"` → ok.
- [x] `mkdocs build --strict` → clean (only pre-existing INFO anchors remain).
- [ ] CI runs green.
- [ ] Post-merge: load the dashboard against a real Prometheus + verify queries resolve. Tracked as a follow-up — needs an actual collector to be set up by ops.

## Dependencies

- PR **#185** (Prometheus metrics) — the SLI series (`zakuro_http_requests_total`, `zakuro_dispatch_latency_seconds`, `zakuro_auth_failure_total`, `zakuro_worker_queue_depth`) come from there. The alerts will evaluate but won't fire usefully until #185 lands.