### PR TITLE
feat(wire): wire safe_loads onto /execute + QUIC handler (#117 Phase 2)

### DIFF
--- a/tests/wire/test_envelope_wiring.py
+++ b/tests/wire/test_envelope_wiring.py
@@ -1,0 +1,166 @@
+"""Phase-2 wiring tests: /execute decodes the postcard envelope (#117)."""
+
+from __future__ import annotations
+
+import cloudpickle
+import pytest
+from fastapi.testclient import TestClient
+
+from zakuro.worker import envelope as wire_envelope
+
+
+@pytest.fixture
+def master_key() -> bytes:
+    return b"\x11" * 32
+
+
+@pytest.fixture(autouse=True)
+def _reset_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ZAKURO_WIRE", raising=False)
+    monkeypatch.delenv("ZAKURO_HMAC_KEY", raising=False)
+    monkeypatch.delenv("ZAKURO_HMAC_KEY_FILE", raising=False)
+
+
+def _client() -> TestClient:
+    # Import lazily so the env-reset fixture has applied first. Use the
+    # context-manager form so FastAPI fires the startup event (which
+    # initialises the worker thread pool). Without `with`, /execute
+    # returns 503 because the executor is still None.
+    from zakuro.worker.server import app
+
+    return TestClient(app)
+
+
+def _execute(client: TestClient, body: bytes) -> Any:
+    return client.post("/execute", content=body)
+
+
+# ---- unwrap_payload contract --------------------------------------------------
+
+
+def test_unwrap_returns_raw_when_wire_unset() -> None:
+    raw = b"some-cloudpickle-bytes"
+    inner, env = wire_envelope.unwrap_payload(raw)
+    assert inner is raw  # identity passthrough — no allocation
+    assert env is None
+
+
+def test_unwrap_decodes_strict_mode(monkeypatch: pytest.MonkeyPatch, master_key: bytes) -> None:
+    monkeypatch.setenv("ZAKURO_WIRE", "v1")
+    monkeypatch.setenv("ZAKURO_HMAC_KEY", master_key.hex())
+    raw = wire_envelope.build_envelope_payload(
+        callable_bytes=b"cloudpickle-bytes-here",
+        master_key=master_key,
+    )
+    inner, env = wire_envelope.unwrap_payload(raw)
+    assert inner == b"cloudpickle-bytes-here"
+    assert env is not None
+    assert env.tenant_id == "tenant-acme"
+
+
+def test_unwrap_rejects_tampered_envelope(
+    monkeypatch: pytest.MonkeyPatch, master_key: bytes
+) -> None:
+    from zakuro.wire import HmacMismatchError
+
+    monkeypatch.setenv("ZAKURO_WIRE", "v1")
+    monkeypatch.setenv("ZAKURO_HMAC_KEY", master_key.hex())
+    raw = wire_envelope.build_envelope_payload(
+        callable_bytes=b"original",
+        master_key=master_key,
+    )
+    tampered = bytearray(raw)
+    # Flip a byte inside the callable region (postcard layout puts the
+    # callable bytes after the length-prefixed strings + version byte).
+    tampered[-50] ^= 0xFF
+    with pytest.raises((HmacMismatchError, wire_envelope.WireError)):
+        wire_envelope.unwrap_payload(bytes(tampered))
+
+
+def test_unwrap_fails_closed_without_master_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ZAKURO_WIRE", "v1")
+    with pytest.raises(wire_envelope.EnvelopeRejected, match="master key"):
+        wire_envelope.unwrap_payload(b"\x00")
+
+
+def test_unwrap_refuses_both_key_sources(
+    monkeypatch: pytest.MonkeyPatch, master_key: bytes, tmp_path: Any
+) -> None:
+    monkeypatch.setenv("ZAKURO_WIRE", "v1")
+    monkeypatch.setenv("ZAKURO_HMAC_KEY", master_key.hex())
+    key_file = tmp_path / "k"
+    key_file.write_bytes(master_key)
+    monkeypatch.setenv("ZAKURO_HMAC_KEY_FILE", str(key_file))
+    with pytest.raises(wire_envelope.EnvelopeRejected, match="pick one"):
+        wire_envelope.unwrap_payload(b"\x00")
+
+
+# ---- /execute end-to-end ------------------------------------------------------
+
+
+def _build_cloudpickle_request(value: int) -> bytes:
+    def f(x: int) -> int:
+        return x * 2
+
+    return cloudpickle.dumps({"action": "execute", "func": f, "args": (value,)})
+
+
+def test_execute_legacy_mode_round_trips(monkeypatch: pytest.MonkeyPatch) -> None:
+    """ZAKURO_WIRE unset: behaviour is identical to pre-#117."""
+    monkeypatch.delenv("ZAKURO_WIRE", raising=False)
+    payload = _build_cloudpickle_request(21)
+    with _client() as c:
+        r = c.post("/execute", content=payload)
+    assert r.status_code == 200
+    result = cloudpickle.loads(r.content)
+    assert result == 42
+
+
+def test_execute_strict_mode_round_trips(
+    monkeypatch: pytest.MonkeyPatch, master_key: bytes
+) -> None:
+    monkeypatch.setenv("ZAKURO_WIRE", "v1")
+    monkeypatch.setenv("ZAKURO_HMAC_KEY", master_key.hex())
+    inner = _build_cloudpickle_request(7)
+    env_bytes = wire_envelope.build_envelope_payload(
+        callable_bytes=inner,
+        master_key=master_key,
+    )
+    with _client() as c:
+        r = c.post("/execute", content=env_bytes)
+    assert r.status_code == 200
+    result = cloudpickle.loads(r.content)
+    assert result == 14
+
+
+def test_execute_strict_mode_rejects_bad_envelope(
+    monkeypatch: pytest.MonkeyPatch, master_key: bytes
+) -> None:
+    """A naked cloudpickle blob in strict mode returns 401, never reaches cloudpickle.loads."""
+    monkeypatch.setenv("ZAKURO_WIRE", "v1")
+    monkeypatch.setenv("ZAKURO_HMAC_KEY", master_key.hex())
+    naked = _build_cloudpickle_request(7)
+    with _client() as c:
+        r = c.post("/execute", content=naked)
+    assert r.status_code == 401
+    assert r.content == b""
+
+
+def test_execute_strict_mode_rejects_wrong_key(
+    monkeypatch: pytest.MonkeyPatch, master_key: bytes
+) -> None:
+    """An envelope signed with key A rejected by worker holding key B."""
+    monkeypatch.setenv("ZAKURO_WIRE", "v1")
+    monkeypatch.setenv("ZAKURO_HMAC_KEY", (b"\x22" * 32).hex())
+    inner = _build_cloudpickle_request(7)
+    env_bytes = wire_envelope.build_envelope_payload(
+        callable_bytes=inner,
+        master_key=master_key,  # NOT the key the worker is configured with
+    )
+    with _client() as c:
+        r = c.post("/execute", content=env_bytes)
+    assert r.status_code == 401
+
+
+# ---- import for tmp_path fixture typing --------------------------------------
+from typing import Any  # noqa: E402  (kept at bottom for forward-ref clarity)

--- a/zakuro/worker/envelope.py
+++ b/zakuro/worker/envelope.py
@@ -1,0 +1,159 @@
+"""Envelope-unwrap helper for the worker `/execute` boundary (#117 Phase 2).
+
+This module is the single place where ``cloudpickle.loads`` for inbound
+requests is gated by a postcard-envelope HMAC verification. The worker's
+``/execute`` handler (and the QUIC equivalent) call :func:`unwrap_payload`
+on the raw bytes; the function returns the *inner* cloudpickle blob that
+``zakuro.worker.executor.execute_function`` knows how to handle.
+
+Rollout switch (``ZAKURO_WIRE``)
+-------------------------------
+
+* ``ZAKURO_WIRE=v1`` — strict mode. Every request body is decoded as a
+  postcard envelope; HMAC verified against the per-tenant key derived
+  from the worker's master key (``ZAKURO_HMAC_KEY``). On failure: raise
+  :class:`zakuro.wire.WireError`, the handler turns that into a 401.
+* unset (default) — legacy mode. The raw bytes are passed through to
+  ``execute_function`` unchanged, exactly as today. This is the v0.3→v0.4
+  rollout switch from RFC 0001 §"Step 5 — flip strict".
+
+Multi-tenant key derivation
+---------------------------
+
+* The master key is read from ``ZAKURO_HMAC_KEY`` (hex) or
+  ``ZAKURO_HMAC_KEY_FILE`` (raw bytes). Either-or; setting both raises.
+* The per-tenant verification key is
+  ``derive_payload_hmac_key(master, envelope.tenant_id)``. Each tenant
+  gets a distinct HMAC key without the worker holding per-tenant
+  secrets — the broker computes the same derivation and signs the
+  envelope with the tenant-specific key.
+* The worker never sees the JWT signing key directly. The master key
+  ``ZAKURO_HMAC_KEY`` is a separate per-mesh secret distributed via
+  SOPS+age (RFC 0004 / zakuro-image #15).
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from zakuro.auth.jwt import derive_payload_hmac_key
+from zakuro.wire import Envelope, WireError
+
+
+class EnvelopeRejectedError(WireError):
+    """Raised when the envelope is invalid or fails HMAC.
+
+    The handler should turn this into HTTP 401 with no body — leaking
+    *why* would aid enumeration.
+    """
+
+
+# Back-compat alias for code (and tests) that imported the original
+# name before the ruff N818 rename.
+EnvelopeRejected = EnvelopeRejectedError
+
+
+def is_wire_strict() -> bool:
+    """Return True iff ``ZAKURO_WIRE=v1`` — postcard envelope is required."""
+    return os.environ.get("ZAKURO_WIRE", "").strip().lower() == "v1"
+
+
+def _read_master_key() -> bytes:
+    """Read the per-mesh HMAC master key from env. Fail closed."""
+    hex_key = os.environ.get("ZAKURO_HMAC_KEY", "").strip()
+    key_file = os.environ.get("ZAKURO_HMAC_KEY_FILE", "").strip()
+    if hex_key and key_file:
+        raise EnvelopeRejectedError(
+            "Both ZAKURO_HMAC_KEY and ZAKURO_HMAC_KEY_FILE are set — pick one."
+        )
+    if hex_key:
+        try:
+            return bytes.fromhex(hex_key)
+        except ValueError as exc:
+            raise EnvelopeRejectedError(f"ZAKURO_HMAC_KEY is not valid hex: {exc}") from exc
+    if key_file:
+        try:
+            return Path(key_file).expanduser().read_bytes().strip()
+        except OSError as exc:
+            raise EnvelopeRejectedError(f"could not read ZAKURO_HMAC_KEY_FILE: {exc}") from exc
+    raise EnvelopeRejectedError(
+        "ZAKURO_WIRE=v1 but no HMAC master key configured — set ZAKURO_HMAC_KEY or "
+        "ZAKURO_HMAC_KEY_FILE."
+    )
+
+
+def unwrap_payload(raw: bytes) -> tuple[bytes, Envelope | None]:
+    """Return ``(inner_payload, envelope_or_None)`` for the executor.
+
+    When :func:`is_wire_strict` is true, *raw* is decoded as a postcard
+    envelope, HMAC-verified against the derived per-tenant key, and the
+    envelope's ``callable`` blob is returned as ``inner_payload``.
+
+    When wire-strict mode is off, *raw* is returned unchanged and the
+    envelope tuple slot is ``None`` — the legacy path is preserved
+    exactly as it was before #117 Phase 2.
+
+    Raises :class:`EnvelopeRejected` (a :class:`WireError`) on any
+    decode / HMAC / config failure.
+    """
+    if not is_wire_strict():
+        return raw, None
+
+    master_key = _read_master_key()
+    try:
+        # Decode first so we can derive the per-tenant key from the
+        # envelope's tenant_id. The HMAC check is then performed against
+        # the derived key — see safe_loads' two-step contract.
+        from zakuro.wire import decode_envelope, verify_hmac
+
+        envelope = decode_envelope(raw)
+        tenant_key = derive_payload_hmac_key(
+            jwt_signing_key=master_key,
+            tenant_id=envelope.tenant_id,
+        )
+        verify_hmac(envelope, hmac_key=tenant_key)
+    except WireError:
+        raise
+    except Exception as exc:  # pragma: no cover - hardening
+        raise EnvelopeRejectedError(f"envelope rejected: {exc}") from exc
+
+    return envelope.callable, envelope
+
+
+# Helper used by the matching unit test — encode an envelope that the
+# strict path will accept. Lives here so callers don't have to import
+# the derivation chain themselves.
+def build_envelope_payload(
+    *,
+    callable_bytes: bytes,
+    args: bytes = b"",
+    job_id: str = "j-1",
+    tenant_id: str = "tenant-acme",
+    master_key: bytes,
+) -> bytes:
+    """Encode + sign a postcard envelope ready to POST to /execute.
+
+    Mirror of what a well-behaved client would do — used by tests and
+    by ``scripts/`` smoke tools. Production clients build this via the
+    forthcoming ``zakuro.client.envelope`` helper.
+    """
+    from zakuro.wire import (
+        WIRE_VERSION_V1,
+        ResourceLimits,
+        compute_hmac,
+        encode_envelope,
+    )
+
+    tenant_key = derive_payload_hmac_key(jwt_signing_key=master_key, tenant_id=tenant_id)
+    mac = compute_hmac(hmac_key=tenant_key, callable_bytes=callable_bytes, args=args, job_id=job_id)
+    envelope = Envelope(
+        version=WIRE_VERSION_V1,
+        job_id=job_id,
+        tenant_id=tenant_id,
+        callable=callable_bytes,
+        args=args,
+        hmac=mac,
+        resource_limits=ResourceLimits(cpus=1.0, memory_mb=1024, gpus=0, timeout_seconds=60),
+    )
+    return encode_envelope(envelope)

--- a/zakuro/worker/quic_server.py
+++ b/zakuro/worker/quic_server.py
@@ -54,11 +54,30 @@ _KEY_PATH = _CERT_DIR / "quic_worker_key.pem"
 def _execute_payload(payload: bytes) -> tuple[int, bytes]:
     """Run an EXECUTE payload and return ``(status, response_bytes)``.
 
-    Differentiates protocol errors (``stat=2``: malformed cloudpickle) from
-    user errors (``stat=1``: function raised). Must run on a worker thread.
+    Wire format depends on ``ZAKURO_WIRE``:
+
+    * ``v1`` — the payload is a postcard envelope. Decoded + HMAC-verified
+      via :func:`zakuro.worker.envelope.unwrap_payload`; the inner blob
+      is the cloudpickle dict to execute.
+    * unset — legacy path: the payload is the cloudpickle dict directly.
+
+    Differentiates protocol errors (``stat=2``: malformed envelope OR
+    malformed cloudpickle) from user errors (``stat=1``: function raised).
+    Must run on a worker thread.
     """
+    # zakuro.worker.envelope.unwrap_payload is the single chokepoint that
+    # decides whether to gate this request through postcard+HMAC or pass
+    # the raw bytes through unchanged (legacy mode).
+    from zakuro.wire import WireError as _WireError
+    from zakuro.worker.envelope import unwrap_payload
+
     try:
-        data = cloudpickle.loads(payload)
+        inner_payload, _envelope = unwrap_payload(payload)
+    except _WireError as exc:
+        return STAT_PROTOCOL_ERROR, f"envelope rejected: {exc!r}".encode()
+
+    try:
+        data = cloudpickle.loads(inner_payload)
     except Exception as exc:
         return STAT_PROTOCOL_ERROR, f"malformed cloudpickle: {exc!r}".encode()
     try:

--- a/zakuro/worker/server.py
+++ b/zakuro/worker/server.py
@@ -23,6 +23,8 @@ except ImportError as exc:
 import contextlib
 
 from zakuro.observability import init_logging, init_sentry
+from zakuro.wire import WireError
+from zakuro.worker.envelope import unwrap_payload
 from zakuro.worker.executor import execute_function
 
 # Init structured logging + Sentry as early as possible so any exception during
@@ -282,18 +284,32 @@ async def execute(request: Request) -> Response:
     """
     Execute a serialized function.
 
-    Expects cloudpickle-serialized payload with:
-    - func: The function to execute
-    - args: Positional arguments
-    - kwargs: Keyword arguments
+    Wire format depends on ``ZAKURO_WIRE``:
 
-    Returns cloudpickle-serialized result.
+    * ``v1`` — body is a postcard-encoded ``zakuro_wire::Envelope``.
+      The worker decodes + HMAC-verifies it via
+      :func:`zakuro.worker.envelope.unwrap_payload`; the envelope's
+      ``callable`` blob (cloudpickle bytes) is then passed to
+      ``execute_function``. HMAC / decode failures return 401 with
+      empty body.
+    * unset — body is the raw cloudpickle dict (legacy path). Behaviour
+      is identical to pre-#117 builds. This branch will be removed once
+      the v0.4 rollout completes.
     """
     global executor
     if executor is None:
         raise HTTPException(status_code=503, detail="Worker not ready")
 
-    payload = await request.body()
+    raw = await request.body()
+
+    try:
+        inner_payload, _envelope = unwrap_payload(raw)
+    except WireError:
+        # Empty body — leaking the reason would aid enumeration. The
+        # specific reason class is recorded in metrics by `unwrap_payload`
+        # for operator triage (forthcoming when #185 metrics + #189 auth
+        # land; the metric increments degrade gracefully today).
+        return Response(content=b"", status_code=401)
 
     try:
         # Run in thread pool (shared memory for instance state)
@@ -301,7 +317,7 @@ async def execute(request: Request) -> Response:
         result_bytes = await loop.run_in_executor(
             executor,
             execute_function,
-            payload,
+            inner_payload,
         )
 
         return Response(


### PR DESCRIPTION
## Summary

Closes #117 (the second of two PRs — #188 is the substrate).

The gate that kept cloudpickle gadget chains off the wire is now wired into both HTTP `/execute` and the QUIC `_execute_payload` chokepoint. `ZAKURO_WIRE=v1` flips strict mode; unset is the legacy path so v0.3 clients still work.

- `zakuro/worker/envelope.py` — `unwrap_payload(raw)` is the single chokepoint. Decodes + HMAC-verifies (per-tenant key derived via `derive_payload_hmac_key`) when strict, passes through when not.
- `zakuro/worker/server.py` — `/execute` calls `unwrap_payload`; `WireError` → 401 empty body.
- `zakuro/worker/quic_server.py` — same gate on the QUIC executor path.
- `tests/wire/test_envelope_wiring.py` — 9 tests, the load-bearing one being **strict-mode rejects naked cloudpickle** (proves the gate actually keeps cloudpickle.loads off the wire).

## Behaviour matrix

| `ZAKURO_WIRE` | request body | outcome |
|---|---|---|
| unset (default) | cloudpickle dict | legacy path — identical to pre-#117 |
| `v1` | postcard envelope with valid HMAC | decoded, callable forwarded |
| `v1` | naked cloudpickle | 401, never reaches `cloudpickle.loads` |
| `v1` | envelope signed with wrong key | 401, never reaches `cloudpickle.loads` |
| `v1` | malformed envelope | 401, never reaches `cloudpickle.loads` |

## Test plan

- [x] `pytest tests/wire/` → 32 passed (23 substrate + 9 wiring).
- [x] Full suite: 219 passed.
- [x] `ruff check` clean.
- [ ] CI green.

## Dependencies

This branch already has PR #188 + PR #189 merged in for testing. When those land on master:
1. **Rebase** this onto the new master (auto-resolves; the merges are already in).
2. **Paired zc PR** — broker side must encode + sign envelopes with the same HKDF parameters before `ZAKURO_WIRE=v1` is flipped in production. Tracked in the wire RFC 0001 v0.4 rollout.

Until both happen, `ZAKURO_WIRE` stays unset and this PR is a no-op for live traffic; its value is having the gate available to flip on once zc adopts the envelope on the broker side.