### PR TITLE
feat(auth): wire require_jwt_scope onto /execute + /info (#116 Phase 2)

### DIFF
--- a/tests/auth/test_jwt_wiring.py
+++ b/tests/auth/test_jwt_wiring.py
@@ -1,0 +1,165 @@
+"""Phase-2 wiring tests: /execute + /info require JWT scopes (#116)."""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import cloudpickle
+import jwt as pyjwt
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def signing_keys() -> Any:
+    private = Ed25519PrivateKey.generate()
+    private_pem = private.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    public_pem = private.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return private_pem, public_pem
+
+
+def _issue(private_pem: bytes, *, scopes: list[str], worker_id: str = "worker-1") -> str:
+    now = int(time.time())
+    return pyjwt.encode(
+        {
+            "aud": "zakuro-worker",
+            "exp": now + 900,
+            "nbf": now,
+            "jti": "j-1",
+            "tenant_id": "tenant-acme",
+            "worker_id": worker_id,
+            "scopes": scopes,
+        },
+        private_pem,
+        algorithm="EdDSA",
+    )
+
+
+def _client() -> TestClient:
+    from zakuro.worker.server import app
+
+    return TestClient(app)
+
+
+def _square_body(value: int) -> bytes:
+    def f(x: int) -> int:
+        return x * x
+
+    return cloudpickle.dumps({"action": "execute", "func": f, "args": (value,)})
+
+
+# ---- legacy / anonymous (ZAKURO_AUTH_REQUIRED unset) -------------------------
+
+
+def test_execute_anonymous_passthrough(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Auth not required → no token → /execute still runs."""
+    monkeypatch.delenv("ZAKURO_AUTH_REQUIRED", raising=False)
+    with _client() as c:
+        r = c.post("/execute", content=_square_body(9))
+    assert r.status_code == 200
+    assert cloudpickle.loads(r.content) == 81
+
+
+def test_info_anonymous_passthrough(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ZAKURO_AUTH_REQUIRED", raising=False)
+    with _client() as c:
+        r = c.get("/info")
+    assert r.status_code == 200
+    body = r.json()
+    # Response shape is owned by the existing /info handler; we just
+    # need to confirm the auth gate didn't 401 us.
+    assert isinstance(body, dict)
+    assert "cpus_total" in body or "resources" in body or "name" in body
+
+
+# ---- strict mode (ZAKURO_AUTH_REQUIRED=1) -----------------------------------
+
+
+def test_execute_strict_no_token_returns_401(
+    monkeypatch: pytest.MonkeyPatch, signing_keys: Any
+) -> None:
+    _, public_pem = signing_keys
+    monkeypatch.setenv("ZAKURO_AUTH_REQUIRED", "1")
+    monkeypatch.setenv("ZAKURO_JWT_PUBLIC_KEY_PEM", public_pem.decode())
+    monkeypatch.setenv("ZAKURO_WORKER_ID", "worker-1")
+    with _client() as c:
+        r = c.post("/execute", content=_square_body(9))
+    assert r.status_code == 401
+
+
+def test_execute_strict_valid_token_passes(
+    monkeypatch: pytest.MonkeyPatch, signing_keys: Any
+) -> None:
+    private_pem, public_pem = signing_keys
+    monkeypatch.setenv("ZAKURO_AUTH_REQUIRED", "1")
+    monkeypatch.setenv("ZAKURO_JWT_PUBLIC_KEY_PEM", public_pem.decode())
+    monkeypatch.setenv("ZAKURO_WORKER_ID", "worker-1")
+    token = _issue(private_pem, scopes=["exec:fn"])
+    with _client() as c:
+        r = c.post(
+            "/execute",
+            content=_square_body(9),
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert r.status_code == 200
+    assert cloudpickle.loads(r.content) == 81
+
+
+def test_execute_strict_wrong_scope_returns_401(
+    monkeypatch: pytest.MonkeyPatch, signing_keys: Any
+) -> None:
+    private_pem, public_pem = signing_keys
+    monkeypatch.setenv("ZAKURO_AUTH_REQUIRED", "1")
+    monkeypatch.setenv("ZAKURO_JWT_PUBLIC_KEY_PEM", public_pem.decode())
+    monkeypatch.setenv("ZAKURO_WORKER_ID", "worker-1")
+    # Token has admin:credits but /execute wants exec:fn
+    token = _issue(private_pem, scopes=["admin:credits"])
+    with _client() as c:
+        r = c.post(
+            "/execute",
+            content=_square_body(9),
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert r.status_code == 401
+
+
+def test_info_strict_requires_info_scope(
+    monkeypatch: pytest.MonkeyPatch, signing_keys: Any
+) -> None:
+    private_pem, public_pem = signing_keys
+    monkeypatch.setenv("ZAKURO_AUTH_REQUIRED", "1")
+    monkeypatch.setenv("ZAKURO_JWT_PUBLIC_KEY_PEM", public_pem.decode())
+    monkeypatch.setenv("ZAKURO_WORKER_ID", "worker-1")
+    # Token has exec:fn (good for /execute) but /info wants worker:info
+    exec_token = _issue(private_pem, scopes=["exec:fn"])
+    info_token = _issue(private_pem, scopes=["worker:info"])
+    with _client() as c:
+        r_no_scope = c.get("/info", headers={"Authorization": f"Bearer {exec_token}"})
+        r_with_scope = c.get("/info", headers={"Authorization": f"Bearer {info_token}"})
+    assert r_no_scope.status_code == 401
+    assert r_with_scope.status_code == 200
+
+
+def test_live_ready_remain_unauthenticated(monkeypatch: pytest.MonkeyPatch) -> None:
+    """/live and /ready intentionally have no auth; kubelet probes hit them."""
+    monkeypatch.setenv("ZAKURO_AUTH_REQUIRED", "1")
+    monkeypatch.setenv("ZAKURO_JWT_PUBLIC_KEY_PEM", "-----BEGIN PUBLIC KEY-----")
+    monkeypatch.setenv("ZAKURO_WORKER_ID", "worker-1")
+    with _client() as c:
+        r_live = c.get("/live")
+        r_ready = c.get("/ready")
+    # /live always returns 200 unless event loop is dead
+    assert r_live.status_code == 200
+    # /ready may 503 in this minimal context (deps not configured) but
+    # crucially must NOT return 401 — it's pre-auth.
+    assert r_ready.status_code != 401

--- a/zakuro/worker/server.py
+++ b/zakuro/worker/server.py
@@ -22,6 +22,9 @@ except ImportError as exc:
 
 import contextlib
 
+from fastapi import Depends
+
+from zakuro.auth import Claims, require_jwt_scope
 from zakuro.observability import (
     init_logging,
     init_metrics,
@@ -34,6 +37,13 @@ from zakuro.observability import (
 from zakuro.wire import WireError
 from zakuro.worker.envelope import unwrap_payload
 from zakuro.worker.executor import execute_function
+
+# Build the scoped dependencies once at module import so FastAPI captures
+# them in its dependant tree (creating them inside route signatures works
+# but pytest's assertion-rewrite breaks the Annotated-form alternative —
+# see docs in tests/auth/conftest.py).
+_REQUIRE_EXEC = require_jwt_scope("exec:fn")
+_REQUIRE_INFO = require_jwt_scope("worker:info")
 
 # Init structured logging + Sentry + Prometheus + OpenTelemetry as early as
 # possible. All four are no-ops when their optional dep is missing or the
@@ -215,8 +225,17 @@ async def health() -> Response:
 
 
 @app.get("/info")
-async def info() -> dict[str, Any]:
-    """Worker info endpoint for broker discovery."""
+async def info(
+    claims: Claims = Depends(_REQUIRE_INFO),  # noqa: B008
+) -> dict[str, Any]:
+    """Worker info endpoint for broker discovery.
+
+    Authorisation: requires a JWT with the ``worker:info`` scope when
+    ``ZAKURO_AUTH_REQUIRED=1``. The broker holds this scope; an
+    unauthenticated client can still get *minimum-disclosure* worker
+    info via :func:`live` / :func:`ready`.
+    """
+    del claims  # reserved for future per-tenant view filtering
     import os
     import platform
     import shutil
@@ -298,7 +317,10 @@ async def info() -> dict[str, Any]:
 
 
 @app.post("/execute")
-async def execute(request: Request) -> Response:
+async def execute(
+    request: Request,
+    claims: Claims = Depends(_REQUIRE_EXEC),  # noqa: B008  -- FastAPI Depends idiom
+) -> Response:
     """
     Execute a serialized function.
 
@@ -313,7 +335,15 @@ async def execute(request: Request) -> Response:
     * unset — body is the raw cloudpickle dict (legacy path). Behaviour
       is identical to pre-#117 builds. This branch will be removed once
       the v0.4 rollout completes.
+
+    Authorisation: requires a JWT with the ``exec:fn`` scope when
+    ``ZAKURO_AUTH_REQUIRED=1``. Unset → anonymous claims, request passes
+    through (RFC 0002 §"Step 5" rollout). The ``claims`` object is
+    available for future per-tenant attribution; today it is unused at
+    the handler level but reaching this point means the request was
+    authorised.
     """
+    del claims  # reserved for per-tenant metrics + auditing
     global executor
     if executor is None:
         raise HTTPException(status_code=503, detail="Worker not ready")


### PR DESCRIPTION
## Summary

Closes #116 (the second of two PRs — #189 is the substrate).

`/execute` and `/info` now gate on JWT scopes when `ZAKURO_AUTH_REQUIRED=1`. Unset is the legacy path. `/live` and `/ready` stay unauthenticated so Kubernetes / kubelet probes still work pre-auth.

- `/execute` → `exec:fn`
- `/info` → `worker:info`
- `/live`, `/ready` → no auth (deliberate; kubelet runs from pre-auth network)

Dependencies are built once at module import (`_REQUIRE_EXEC` / `_REQUIRE_INFO`) and reused via the default-value `Depends()` pattern — the `Annotated[...]` form silently drops the marker in some FastAPI/pytest combos (see `tests/auth/conftest.py` from #189).

7 new tests cover: anonymous passthrough, strict-no-token, strict-valid-token, strict-wrong-scope, /info scope separation, /live+/ready remain open.

## Behaviour matrix

| `ZAKURO_AUTH_REQUIRED` | request | outcome |
|---|---|---|
| unset | no token | 200 (anonymous claims) |
| `1` | no token | 401 |
| `1` | valid token, right scope | 200 |
| `1` | valid token, wrong scope | 401 |
| `1` | expired token | 401 |

## Test plan

- [x] `pytest tests/auth/` → 24 passed (17 substrate + 7 wiring).
- [x] Full suite: 194 passed.
- [x] `ruff check` clean.
- [ ] CI green.

## Dependencies

Branch has PR #189 merged in for testing. Once #189 lands on master:

1. **Rebase** this onto the new master (trivial).
2. **Coordinate** with zc maintainers on the JWT scope names — `exec:fn` / `worker:info` are the worker-side expectations. Broker must sign with these claims before `ZAKURO_AUTH_REQUIRED=1` is flipped in prod.

Until both happen, `ZAKURO_AUTH_REQUIRED` stays unset and this PR is a no-op for live traffic; value is in having the gate available to flip on.