### PR TITLE
docs(adaptive): document the routing knobs that already exist (#171, #172, #173)

### DIFF
--- a/zakuro/adaptive.py
+++ b/zakuro/adaptive.py
@@ -192,6 +192,67 @@ class AdaptiveCompute:
     backpressure_threshold:
         ``is_backpressured`` returns ``True`` when *every* worker's
         expected time-to-serve exceeds this many seconds.
+
+    cost_coefficient:
+        Price-aware routing knob (Phase 4.3, #173). At ``0`` (default) the
+        allocator ignores ``Compute.price_per_hour`` entirely. Positive
+        values scale each worker's expected time by
+        ``1 + cost_coefficient × price``, so more-expensive workers fall
+        further down the picker's queue. Higher values trade speed for
+        spend; ``0.5`` is a reasonable starting point. See
+        ``tests/test_adaptive.py::TestPriceAware`` for measured behaviour.
+
+    local_region, local_rack:
+        Topology preference (Phase 4.2, #172). When set, the allocator
+        softly demotes workers in a *different* region (and, within a
+        matching region, a different rack). The bandwidth map (#171) is
+        the source of truth for actual transfer cost; topology hints are
+        a tie-breaker — they never overrule a faster remote worker on
+        latency. Defaults are read from ``ZAKURO_REGION`` / ``ZAKURO_RACK``
+        env vars when ``None``.
+    region_penalty, rack_penalty:
+        Multipliers (≥ 1.0) applied to cross-region and cross-rack
+        workers respectively. Both default to small (1.10 / 1.03) so a
+        materially faster remote worker still wins — see
+        ``tests/test_adaptive.py::TestTopologyHints::test_faster_remote_still_wins``.
+
+    Bandwidth awareness (Phase 4.1, #171) is enabled per call via the
+    ``payload_bytes`` argument to :meth:`pick`: if non-zero and the
+    worker has a bandwidth estimate (seeded during warmup or set by the
+    caller), the picker adds ``payload_bytes / bandwidth_bps`` to each
+    worker's expected time. Critical for large state-dict dispatches.
+
+    Examples
+    --------
+
+    Price-aware (Phase 4.3)::
+
+        ac = zk.AdaptiveCompute(
+            workers=[
+                zk.Compute(uri="quic://onprem:4433", price_per_hour=0.10),
+                zk.Compute(uri="quic://cloud:4433", price_per_hour=1.40),
+            ],
+            cost_coefficient=0.5,  # 0 = speed-only; 1.0 ≈ cost-only
+        )
+
+    Topology hints (Phase 4.2)::
+
+        ac = zk.AdaptiveCompute(
+            workers=[
+                zk.Compute(uri="quic://a.us-west:4433", region="us-west"),
+                zk.Compute(uri="quic://b.eu-west:4433", region="eu-west"),
+            ],
+            local_region="us-west",
+        )
+
+    Bandwidth-aware dispatch (Phase 4.1)::
+
+        # During warmup, AdaptiveCompute probes each worker with a
+        # large payload and seeds bandwidth_bps. After that, pass the
+        # payload size on each dispatch so the picker weights transfer
+        # time alongside latency:
+        ac.warmup(bandwidth_probe_bytes=8_000_000)
+        ac.pick(payload_bytes=len(state_dict_bytes))
     """
 
     def __init__(


### PR DESCRIPTION
## Summary

Closes #171, #172, #173 — all three routing enhancements shipped earlier as part of the AdaptiveCompute v0.2 cycle, but the public docstring never mentioned the new constructor params. This PR closes the loop:

- **Phase 4.1 — Bandwidth map (#171)**: implemented at `zakuro/adaptive.py:_expected_times_locked` (line 836); tested by `TestBandwidthAware`. Warmup seeds `bandwidth_bps`; `pick(payload_bytes=...)` factors transfer time.
- **Phase 4.2 — Topology hints (#172)**: implemented at `zakuro/adaptive.py:_expected_times_locked` (line 850); tested by `TestTopologyHints`. `region_penalty=1.10` / `rack_penalty=1.03` defaults so a materially faster remote worker still wins on latency.
- **Phase 4.3 — Price-aware routing (#173)**: implemented at `zakuro/adaptive.py:_expected_times_locked` (line 843); tested by `TestPriceAware`. `cost_coefficient=0` = ignore price; positive values scale expected time by `1 + coef × price`.

This PR adds the missing **parameter docs** + **examples section** + **test pointers** to the `AdaptiveCompute` docstring.

## Test plan

- [x] Existing tests still pass — 9 routing tests, 37 total adaptive tests.
- [x] `ruff check` clean.
- [x] No code changes outside the docstring; behaviour identical.