### PR TITLE
feat(wire): zakuro-wire v0.2 — EnvelopeV2 + ChunkFrame substrate (#174, #175)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,7 +138,7 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "zakuro-wire"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "hex",
  "postcard",

--- a/crates/zakuro-wire/Cargo.toml
+++ b/crates/zakuro-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakuro-wire"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/zakuro-wire/src/lib.rs
+++ b/crates/zakuro-wire/src/lib.rs
@@ -82,6 +82,12 @@ use serde::{Deserialize, Serialize};
 pub enum WireVersion {
     /// Initial wire format, shipped with zakuro 0.4 / zc 0.1.
     V1,
+    /// v0.2: adds optional `cache_key` + `delta_against` on the
+    /// envelope (state-dict delta encoding, zakuro RFC 0001 amendment),
+    /// and the streaming [`ChunkFrame`] message for multi-chunk payloads.
+    /// Workers that understand `V2` also accept `V1` envelopes — a
+    /// v0.2 worker is a strict superset of a v0.1 worker.
+    V2,
 }
 
 /// Per-job resource budget enforced by the worker container.
@@ -218,6 +224,103 @@ pub enum ErrorKind {
     },
 }
 
+// =========================================================================
+// v0.2 additions — separate structs so v0.1 byte layout is unchanged.
+// =========================================================================
+
+/// Dispatch envelope, v0.2 (zakuro RFC 0001 amendment).
+///
+/// Carries the same fields as [`Envelope`] plus the optional
+/// `cache_key` and `delta_against` slots used by the state-dict delta
+/// encoding (zakuro #174). When `delta_against == Some(prev_key)`, the
+/// `callable` bytes are a delta against the value the worker previously
+/// cached under `prev_key`; the worker reconstructs the full payload
+/// before passing it to `cloudpickle.loads`. When `delta_against == None`,
+/// the envelope behaves exactly like [`Envelope`] — and `cache_key`, if
+/// set, tells the worker to remember the reconstructed payload for
+/// subsequent delta dispatches.
+///
+/// Postcard byte layout puts the v0.1 fields first (identical to the
+/// `Envelope` layout) and then the two `Option<String>` fields, so the
+/// first byte (`WireVersion::V2`) is the discriminator that lets a v0.2
+/// worker pick the right decoder.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EnvelopeV2 {
+    /// Wire version. Always populated; must be [`WireVersion::V2`] for
+    /// values that travel as `EnvelopeV2`.
+    pub version: WireVersion,
+    /// Same semantics as [`Envelope::job_id`].
+    pub job_id: String,
+    /// Same semantics as [`Envelope::tenant_id`].
+    pub tenant_id: String,
+    /// Same semantics as [`Envelope::callable`]. May carry a delta
+    /// (see `delta_against`) rather than the full callable.
+    #[serde(with = "serde_bytes")]
+    pub callable: Vec<u8>,
+    /// Same semantics as [`Envelope::args`].
+    #[serde(with = "serde_bytes")]
+    pub args: Vec<u8>,
+    /// Same semantics as [`Envelope::hmac`]. Computed over
+    /// `callable || args || job_id`, identical layout to v0.1.
+    pub hmac: [u8; 32],
+    /// Same semantics as [`Envelope::resource_limits`].
+    pub resource_limits: ResourceLimits,
+    /// Cache slot the worker should populate (or refresh) after this
+    /// dispatch's `callable` has been fully reconstructed. `None` means
+    /// "don't cache". Bounded LRU on the worker side; caller is
+    /// responsible for picking a key that's stable across iterations
+    /// of the same training loop.
+    pub cache_key: Option<String>,
+    /// When `Some(key)`, the `callable` field is a delta against the
+    /// value the worker previously cached under `key`. The worker
+    /// rejects with [`ErrorKind::WorkerUnavailable { reason: "cache_miss" }`]
+    /// if the key is absent — caller should retry with the full payload.
+    pub delta_against: Option<String>,
+}
+
+/// Streaming-chunk frame (zakuro #175).
+///
+/// Large payloads (multi-gigabyte state-dicts) can be fragmented into
+/// `ChunkFrame`s so the worker can start deserialisation before the
+/// last byte has arrived. Each chunk carries its `stream_id` (so
+/// multiple concurrent chunked dispatches don't interleave), a
+/// monotonic `seq`, a `last` flag marking the final chunk, and the
+/// payload `bytes`. The worker reassembles in order and treats the
+/// concatenated bytes as a v0.2 envelope once the last chunk is in.
+///
+/// Frames are sent as their own top-level message — the worker
+/// dispatches on the first byte (`WireVersion::V2`) plus the
+/// length-prefix discriminator from the [`V2Message`] enum.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChunkFrame {
+    /// Wire version. Must be [`WireVersion::V2`].
+    pub version: WireVersion,
+    /// Stream identifier — distinguishes concurrent chunked dispatches.
+    pub stream_id: u64,
+    /// 0-indexed sequence within the stream. Workers reject out-of-order
+    /// chunks with [`ErrorKind::WorkerUnavailable { reason: "chunk_oos" }`].
+    pub seq: u32,
+    /// `true` on the final chunk. The worker triggers reassembly +
+    /// envelope decode after this is observed.
+    pub last: bool,
+    /// Chunk payload. Concatenation of every `bytes` field (in `seq`
+    /// order) yields the postcard-encoded [`EnvelopeV2`].
+    #[serde(with = "serde_bytes")]
+    pub bytes: Vec<u8>,
+}
+
+/// Top-level v0.2 message: callers serialise this to switch between
+/// envelope + chunk-frame shapes on the wire. v0.1 peers reject the
+/// outer enum tag as an unknown variant and surface
+/// [`ErrorKind::UnknownWireVersion`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum V2Message {
+    /// A full v0.2 envelope (one logical dispatch).
+    Envelope(EnvelopeV2),
+    /// A single streaming chunk for a multi-chunk dispatch.
+    Chunk(ChunkFrame),
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -277,5 +380,137 @@ mod tests {
         let bytes = postcard::to_allocvec(&res).expect("encode");
         let back: ExecutionResult = postcard::from_bytes(&bytes).expect("decode");
         assert_eq!(res, back);
+    }
+
+    // ----- v0.2 additions -------------------------------------------------
+
+    fn _canonical_envelope_v2_full() -> EnvelopeV2 {
+        EnvelopeV2 {
+            version: WireVersion::V2,
+            job_id: "canonical-job".into(),
+            tenant_id: "canonical-tenant".into(),
+            callable: vec![0xde, 0xad, 0xbe, 0xef],
+            args: vec![0x00, 0x01, 0x02],
+            hmac: [0xaa; 32],
+            resource_limits: ResourceLimits {
+                cpus: 1.0,
+                memory_mb: 1024,
+                gpus: 0,
+                timeout_seconds: 30,
+            },
+            cache_key: Some("epoch-1-bert-base".into()),
+            delta_against: Some("epoch-0-bert-base".into()),
+        }
+    }
+
+    #[test]
+    fn envelope_v2_roundtrip_with_delta_fields() {
+        let env = _canonical_envelope_v2_full();
+        let bytes = postcard::to_allocvec(&env).expect("encode");
+        let back: EnvelopeV2 = postcard::from_bytes(&bytes).expect("decode");
+        assert_eq!(env, back);
+    }
+
+    #[test]
+    fn envelope_v2_roundtrip_without_delta_fields() {
+        // The Some/None encoding distinguishes "no caching wanted" from
+        // "cache under empty string". A None should round-trip cleanly.
+        let mut env = _canonical_envelope_v2_full();
+        env.cache_key = None;
+        env.delta_against = None;
+        let bytes = postcard::to_allocvec(&env).expect("encode");
+        let back: EnvelopeV2 = postcard::from_bytes(&bytes).expect("decode");
+        assert_eq!(env, back);
+        // Empty-Option encoding is byte-shorter than the Some encoding —
+        // confirms the v0.2 envelope is *additive*, not a hard size hit
+        // for callers that don't opt into deltas.
+        let env_with = _canonical_envelope_v2_full();
+        let bytes_with = postcard::to_allocvec(&env_with).expect("encode");
+        assert!(bytes.len() < bytes_with.len());
+    }
+
+    #[test]
+    fn chunk_frame_roundtrip() {
+        let chunk = ChunkFrame {
+            version: WireVersion::V2,
+            stream_id: 0xdead_beef,
+            seq: 7,
+            last: false,
+            bytes: vec![0x10, 0x20, 0x30, 0x40, 0x50],
+        };
+        let bytes = postcard::to_allocvec(&chunk).expect("encode");
+        let back: ChunkFrame = postcard::from_bytes(&bytes).expect("decode");
+        assert_eq!(chunk, back);
+    }
+
+    #[test]
+    fn chunk_frame_last_marker_distinguished() {
+        // Two chunks identical except for `last` must serialise to distinct
+        // bytes — postcard encodes bool as a single byte, so this is a
+        // sanity check that no compiler fold collapses the field.
+        let mut a = ChunkFrame {
+            version: WireVersion::V2,
+            stream_id: 1,
+            seq: 0,
+            last: false,
+            bytes: vec![0xaa],
+        };
+        let bytes_a = postcard::to_allocvec(&a).expect("encode a");
+        a.last = true;
+        let bytes_b = postcard::to_allocvec(&a).expect("encode b");
+        assert_ne!(bytes_a, bytes_b);
+    }
+
+    #[test]
+    fn v2_message_dispatch_envelope() {
+        let msg = V2Message::Envelope(_canonical_envelope_v2_full());
+        let bytes = postcard::to_allocvec(&msg).expect("encode");
+        let back: V2Message = postcard::from_bytes(&bytes).expect("decode");
+        assert_eq!(msg, back);
+        match back {
+            V2Message::Envelope(env) => assert_eq!(env.tenant_id, "canonical-tenant"),
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[test]
+    fn v2_message_dispatch_chunk() {
+        let msg = V2Message::Chunk(ChunkFrame {
+            version: WireVersion::V2,
+            stream_id: 99,
+            seq: 0,
+            last: true,
+            bytes: vec![0xff; 4],
+        });
+        let bytes = postcard::to_allocvec(&msg).expect("encode");
+        let back: V2Message = postcard::from_bytes(&bytes).expect("decode");
+        assert_eq!(msg, back);
+        match back {
+            V2Message::Chunk(c) => assert!(c.last),
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[test]
+    fn v1_envelope_first_byte_unchanged() {
+        // Regression guard: a fresh v0.1 envelope must still serialise to
+        // bytes starting with 0x00 (WireVersion::V1 = variant 0). v0.2
+        // additions must not have perturbed the v0.1 layout.
+        let env = Envelope {
+            version: WireVersion::V1,
+            job_id: "j".into(),
+            tenant_id: "t".into(),
+            callable: vec![],
+            args: vec![],
+            hmac: [0u8; 32],
+            resource_limits: ResourceLimits {
+                cpus: 1.0,
+                memory_mb: 1,
+                gpus: 0,
+                timeout_seconds: 1,
+            },
+        };
+        let bytes = postcard::to_allocvec(&env).expect("encode");
+        assert_eq!(bytes[0], 0x00, "v0.1 envelope must still start with byte 0x00");
     }
 }

--- a/crates/zakuro-wire/src/lib.rs
+++ b/crates/zakuro-wire/src/lib.rs
@@ -384,7 +384,7 @@ mod tests {
 
     // ----- v0.2 additions -------------------------------------------------
 
-    fn _canonical_envelope_v2_full() -> EnvelopeV2 {
+    fn canonical_envelope_v2_full() -> EnvelopeV2 {
         EnvelopeV2 {
             version: WireVersion::V2,
             job_id: "canonical-job".into(),
@@ -405,7 +405,7 @@ mod tests {
 
     #[test]
     fn envelope_v2_roundtrip_with_delta_fields() {
-        let env = _canonical_envelope_v2_full();
+        let env = canonical_envelope_v2_full();
         let bytes = postcard::to_allocvec(&env).expect("encode");
         let back: EnvelopeV2 = postcard::from_bytes(&bytes).expect("decode");
         assert_eq!(env, back);
@@ -415,7 +415,7 @@ mod tests {
     fn envelope_v2_roundtrip_without_delta_fields() {
         // The Some/None encoding distinguishes "no caching wanted" from
         // "cache under empty string". A None should round-trip cleanly.
-        let mut env = _canonical_envelope_v2_full();
+        let mut env = canonical_envelope_v2_full();
         env.cache_key = None;
         env.delta_against = None;
         let bytes = postcard::to_allocvec(&env).expect("encode");
@@ -424,7 +424,7 @@ mod tests {
         // Empty-Option encoding is byte-shorter than the Some encoding —
         // confirms the v0.2 envelope is *additive*, not a hard size hit
         // for callers that don't opt into deltas.
-        let env_with = _canonical_envelope_v2_full();
+        let env_with = canonical_envelope_v2_full();
         let bytes_with = postcard::to_allocvec(&env_with).expect("encode");
         assert!(bytes.len() < bytes_with.len());
     }
@@ -463,13 +463,13 @@ mod tests {
 
     #[test]
     fn v2_message_dispatch_envelope() {
-        let msg = V2Message::Envelope(_canonical_envelope_v2_full());
+        let msg = V2Message::Envelope(canonical_envelope_v2_full());
         let bytes = postcard::to_allocvec(&msg).expect("encode");
         let back: V2Message = postcard::from_bytes(&bytes).expect("decode");
         assert_eq!(msg, back);
         match back {
             V2Message::Envelope(env) => assert_eq!(env.tenant_id, "canonical-tenant"),
-            _ => panic!("wrong variant"),
+            V2Message::Chunk(_) => panic!("expected Envelope variant"),
         }
     }
 
@@ -487,7 +487,7 @@ mod tests {
         assert_eq!(msg, back);
         match back {
             V2Message::Chunk(c) => assert!(c.last),
-            _ => panic!("wrong variant"),
+            V2Message::Envelope(_) => panic!("expected Chunk variant"),
         }
     }
 
@@ -511,6 +511,9 @@ mod tests {
             },
         };
         let bytes = postcard::to_allocvec(&env).expect("encode");
-        assert_eq!(bytes[0], 0x00, "v0.1 envelope must still start with byte 0x00");
+        assert_eq!(
+            bytes[0], 0x00,
+            "v0.1 envelope must still start with byte 0x00"
+        );
     }
 }

--- a/docs/rfcs/0001-wire-format-postcard.md
+++ b/docs/rfcs/0001-wire-format-postcard.md
@@ -91,3 +91,45 @@ Rationale for postcard:
 - HMAC key derivation: per-tenant or per-worker? Decision deferred to RFC 0002.
 - `serde-pyobject` vs a hand-rolled `From<PyAny>` impl: defer to first implementation PR; benchmark both.
 - Compression (zstd?) on the envelope's `args` field for ML payloads: defer to a separate "wire payload size" investigation once v2 is live.
+
+## Amendment — v0.2 wire (#174, #175)
+
+**Status:** Accepted (2026-05). Crate version bumped to `zakuro-wire = 0.2.0`.
+
+v0.2 introduces three new types alongside (not replacing) the v0.1 `Envelope`. v0.1 callers stay byte-compatible; v0.2-capable workers accept both.
+
+### Added types
+
+- `EnvelopeV2` — same shape as `Envelope` plus:
+  - `cache_key: Option<String>` — when present, the worker stores the (reconstructed) callable bytes in its bounded LRU under this key.
+  - `delta_against: Option<String>` — when present, `callable` is a delta against the value cached under this key. The worker reconstructs the full payload before invoking the deserialiser. Cache-miss is signalled as `ErrorKind::WorkerUnavailable { reason: "cache_miss" }`; the caller retries with the full payload.
+- `ChunkFrame` — one frame in a multi-chunk streaming dispatch:
+  - `stream_id: u64` — distinguishes concurrent chunked dispatches.
+  - `seq: u32` — 0-indexed monotonic sequence within the stream.
+  - `last: bool` — true on the final chunk; triggers reassembly.
+  - `bytes: Vec<u8>` — chunk payload. Concatenation in `seq` order yields a postcard-encoded `EnvelopeV2`.
+- `V2Message` — top-level enum: `Envelope(EnvelopeV2)` or `Chunk(ChunkFrame)`. Callers serialise this so the worker dispatches on the variant tag.
+
+### Wire-format invariants
+
+- `Envelope` v0.1 byte layout is **unchanged**. A regression test (`v1_envelope_first_byte_unchanged`) asserts the first byte is still `0x00`.
+- `EnvelopeV2` starts with `0x01` (`WireVersion::V2`). v0.1 workers reject this as `UnknownWireVersion`.
+- `Option<String>` follows postcard convention: `0x00` = None; `0x01` + length-prefixed UTF-8 when Some. A None-valued v0.2 envelope is byte-shorter than a Some-valued one (regression test asserts this so an absent-deltas dispatch isn't unfairly penalised).
+
+### Backwards / forwards compat
+
+- A v0.1 broker dispatching v0.1 `Envelope`s to a v0.2 worker → works unchanged.
+- A v0.2 broker dispatching `EnvelopeV2` to a v0.1 worker → worker rejects with `UnknownWireVersion` (the first-byte tag is `0x01`, which doesn't exist in v0.1's `WireVersion` enum). Broker falls back to v0.1 `Envelope` per the worker's `/info`-advertised wire-version (forthcoming claim on `/info`).
+- A v0.2 broker dispatching `EnvelopeV2` with `delta_against: Some(...)` to a v0.2 worker whose cache is cold → worker replies `WorkerUnavailable { reason: "cache_miss" }`; broker retries with full payload (no delta).
+
+### Cache eviction policy
+
+Cache lives on the worker, bounded by an LRU of N entries × cap-per-entry, both configurable via `ZAKURO_CACHE_MAX_ENTRIES` / `ZAKURO_CACHE_MAX_BYTES`. Defaults: 32 entries / 4 GB. Eviction is silent — callers that suffer a cache-miss on a delta retry with the full payload, which is the same code path as never having cached.
+
+### Phase 2 follow-up
+
+This PR ships the schema substrate only. The worker-side reassembly + delta-apply logic lands as a Phase 2 PR (mirroring the #115 / #116 / #117 substrate-vs-wiring split). Until that lands, v0.2 envelopes round-trip through the schema cleanly but the worker treats `cache_key` / `delta_against` as advisory metadata.
+
+### Cross-repo
+
+`zc` adopts `zakuro-wire = 0.2.0` simultaneously per the multi-repo coherence rule. The integration test in `.github/workflows/integration.yml` covers the matrix: v0.1 broker × v0.1 worker (today), v0.1 broker × v0.2 worker (back-compat), and v0.2 broker × v0.2 worker (new path) once the matrix expands.

--- a/tests/wire/test_wire_v2.py
+++ b/tests/wire/test_wire_v2.py
@@ -1,0 +1,180 @@
+"""Tests for the v0.2 wire surface (#174 EnvelopeV2 + #175 ChunkFrame)."""
+
+from __future__ import annotations
+
+import pytest
+
+from zakuro.wire import (
+    WIRE_VERSION_V2,
+    ChunkFrame,
+    EnvelopeV2,
+    ResourceLimits,
+    UnknownWireVersionError,
+    WireDecodeError,
+    decode_chunk_frame,
+    decode_envelope_v2,
+    encode_chunk_frame,
+    encode_envelope_v2,
+)
+
+
+def _canonical_v2(*, cache_key: str | None = None, delta_against: str | None = None) -> EnvelopeV2:
+    return EnvelopeV2(
+        version=WIRE_VERSION_V2,
+        job_id="canonical-job",
+        tenant_id="canonical-tenant",
+        callable=bytes.fromhex("deadbeef"),
+        args=bytes.fromhex("000102"),
+        hmac=bytes([0xAA]) * 32,
+        resource_limits=ResourceLimits(cpus=1.0, memory_mb=1024, gpus=0, timeout_seconds=30),
+        cache_key=cache_key,
+        delta_against=delta_against,
+    )
+
+
+# ---- EnvelopeV2 -------------------------------------------------------------
+
+
+def test_envelope_v2_round_trip_with_delta_fields() -> None:
+    env = _canonical_v2(cache_key="epoch-1", delta_against="epoch-0")
+    raw = encode_envelope_v2(env)
+    back = decode_envelope_v2(raw)
+    assert back == env
+
+
+def test_envelope_v2_round_trip_without_delta_fields() -> None:
+    env = _canonical_v2()
+    raw = encode_envelope_v2(env)
+    back = decode_envelope_v2(raw)
+    assert back == env
+    assert back.cache_key is None
+    assert back.delta_against is None
+
+
+def test_envelope_v2_none_encoding_smaller_than_some() -> None:
+    """None fields cost 1 byte each; Some fields cost 1 + varint(len) + len."""
+    with_keys = encode_envelope_v2(_canonical_v2(cache_key="abc", delta_against="def"))
+    without_keys = encode_envelope_v2(_canonical_v2())
+    assert len(without_keys) < len(with_keys)
+    assert len(with_keys) - len(without_keys) == (1 + 1 + 3) - 1 + (1 + 1 + 3) - 1
+
+
+def test_envelope_v2_first_byte_is_v2_tag() -> None:
+    raw = encode_envelope_v2(_canonical_v2())
+    assert raw[0] == WIRE_VERSION_V2 == 1
+
+
+def test_envelope_v2_rejects_v1_version_tag() -> None:
+    with pytest.raises(UnknownWireVersionError):
+        EnvelopeV2(
+            version=0,  # V1
+            job_id="j",
+            tenant_id="t",
+            callable=b"",
+            args=b"",
+            hmac=b"\x00" * 32,
+        )
+
+
+def test_envelope_v2_decode_rejects_v1_bytes() -> None:
+    """Bytes that start with V1 (0x00) must not be parsed as V2 envelopes."""
+    v1_like = b"\x00" + b"\x01a\x01b" + b"\x00" * 50
+    with pytest.raises(UnknownWireVersionError):
+        decode_envelope_v2(v1_like)
+
+
+def test_envelope_v2_trailing_bytes_rejected() -> None:
+    raw = encode_envelope_v2(_canonical_v2()) + b"\x00"
+    with pytest.raises(WireDecodeError, match="trailing"):
+        decode_envelope_v2(raw)
+
+
+def test_envelope_v2_unknown_option_tag_rejected() -> None:
+    raw = encode_envelope_v2(_canonical_v2())
+    tampered = bytearray(raw)
+    # Find the cache_key Option tag (should be the second-to-last region)
+    # and corrupt the first option byte to an invalid tag.
+    # The encoding ends with: <cache_key tag><cache_key payload?><delta tag>...
+    # For a Both-None envelope the last two bytes are 0x00 0x00. Flip the
+    # first to 0x02 (invalid) and expect rejection.
+    tampered[-2] = 0x02
+    with pytest.raises(WireDecodeError, match="Option<String> tag"):
+        decode_envelope_v2(bytes(tampered))
+
+
+# ---- ChunkFrame --------------------------------------------------------------
+
+
+def test_chunk_frame_round_trip() -> None:
+    c = ChunkFrame(
+        version=WIRE_VERSION_V2,
+        stream_id=0xDEADBEEF,
+        seq=7,
+        last=False,
+        bytes_=b"\x10\x20\x30\x40\x50",
+    )
+    raw = encode_chunk_frame(c)
+    back = decode_chunk_frame(raw)
+    assert back == c
+
+
+def test_chunk_frame_last_marker_distinguishes_bytes() -> None:
+    c0 = ChunkFrame(version=WIRE_VERSION_V2, stream_id=1, seq=0, last=False, bytes_=b"\xaa")
+    c1 = ChunkFrame(version=WIRE_VERSION_V2, stream_id=1, seq=0, last=True, bytes_=b"\xaa")
+    assert encode_chunk_frame(c0) != encode_chunk_frame(c1)
+
+
+def test_chunk_frame_rejects_invalid_last_byte() -> None:
+    raw = encode_chunk_frame(
+        ChunkFrame(version=WIRE_VERSION_V2, stream_id=1, seq=0, last=False, bytes_=b"")
+    )
+    tampered = bytearray(raw)
+    # The `last` flag is exactly after stream_id (varint) + seq (varint).
+    # For stream_id=1 (single byte) + seq=0 (single byte), it sits at
+    # offset 1 + 1 + 1 = 3.
+    tampered[3] = 0x02
+    with pytest.raises(WireDecodeError, match="last-flag"):
+        decode_chunk_frame(bytes(tampered))
+
+
+def test_chunk_frame_large_stream_id_is_u64() -> None:
+    """stream_id must accept full u64 range — varint can be up to 10 bytes."""
+    c = ChunkFrame(
+        version=WIRE_VERSION_V2,
+        stream_id=2**63,  # well above u32
+        seq=0,
+        last=True,
+        bytes_=b"",
+    )
+    raw = encode_chunk_frame(c)
+    back = decode_chunk_frame(raw)
+    assert back.stream_id == 2**63
+
+
+def test_chunk_frame_rejects_v1_version_tag() -> None:
+    v1_like = b"\x00\x01\x00\x00\x00"
+    with pytest.raises(UnknownWireVersionError):
+        decode_chunk_frame(v1_like)
+
+
+def test_chunk_frame_round_trip_stream_assembly() -> None:
+    """Concatenating bytes_ in seq order reconstructs the original payload."""
+    payload = b"the quick brown fox jumps over the lazy dog" * 20
+    chunks = []
+    for i in range(0, len(payload), 100):
+        slice_ = payload[i : i + 100]
+        chunks.append(
+            ChunkFrame(
+                version=WIRE_VERSION_V2,
+                stream_id=42,
+                seq=i // 100,
+                last=(i + 100 >= len(payload)),
+                bytes_=slice_,
+            )
+        )
+    # Encode + decode each and re-assemble
+    decoded = [decode_chunk_frame(encode_chunk_frame(c)) for c in chunks]
+    decoded.sort(key=lambda c: c.seq)
+    assert b"".join(c.bytes_ for c in decoded) == payload
+    assert decoded[-1].last is True
+    assert all(not c.last for c in decoded[:-1])

--- a/zakuro/wire/__init__.py
+++ b/zakuro/wire/__init__.py
@@ -142,9 +142,23 @@ def _enc_varint(value: int) -> bytes:
 
 def _dec_varint(buf: memoryview, offset: int) -> tuple[int, int]:
     """Decode a postcard varint; return (value, new_offset). Caps at 5 bytes (u32)."""
+    return _dec_varint_n(buf, offset, max_bytes=5)
+
+
+def _dec_varint_u64(buf: memoryview, offset: int) -> tuple[int, int]:
+    """Decode a postcard varint capped at 10 bytes (u64).
+
+    Postcard uses the same LEB128 layout regardless of width; the cap is
+    what changes. v0.2's ``ChunkFrame.stream_id`` is a u64 and needs the
+    wider variant.
+    """
+    return _dec_varint_n(buf, offset, max_bytes=10)
+
+
+def _dec_varint_n(buf: memoryview, offset: int, *, max_bytes: int) -> tuple[int, int]:
     value = 0
     shift = 0
-    for byte_count in range(5):
+    for byte_count in range(max_bytes):
         if offset >= len(buf):
             raise WireDecodeError("varint truncated")
         byte = buf[offset]
@@ -153,8 +167,8 @@ def _dec_varint(buf: memoryview, offset: int) -> tuple[int, int]:
         if not (byte & 0x80):
             return value, offset
         shift += 7
-        if byte_count == 4 and (byte & 0x80):
-            raise WireDecodeError("varint overflow (> 5 bytes)")
+        if byte_count == max_bytes - 1 and (byte & 0x80):
+            raise WireDecodeError(f"varint overflow (> {max_bytes} bytes)")
     raise WireDecodeError("varint did not terminate")
 
 
@@ -301,17 +315,243 @@ def safe_loads(raw: bytes, *, hmac_key: bytes) -> Envelope:
     return env
 
 
+# =====================================================================
+# v0.2 — state-dict delta encoding (#174) + streaming chunks (#175).
+# Separate dataclasses + codec entries so v0.1 byte layout is unchanged.
+# Mirrors zakuro_wire::{EnvelopeV2, ChunkFrame, V2Message}.
+# =====================================================================
+
+# WireVersion::V2 variant index — postcard encodes it as a single byte.
+WIRE_VERSION_V2 = 1
+
+
+@dataclass(frozen=True)
+class EnvelopeV2:
+    """v0.2 dispatch envelope.
+
+    Identical to :class:`Envelope` plus two new optional slots:
+
+    * ``cache_key`` — when set, the worker stores the reconstructed
+      ``callable`` bytes in its bounded LRU under this key.
+    * ``delta_against`` — when set, ``callable`` is a delta against the
+      value the worker previously cached under this key. The worker
+      reconstructs the full payload before invoking cloudpickle. A
+      cache-miss is signalled as a `worker_unavailable` reason — the
+      caller retries with the full payload.
+
+    Wire-format invariants
+    ----------------------
+    * ``version`` MUST be :data:`WIRE_VERSION_V2`.
+    * Postcard layout: v0.1 fields first (identical to :class:`Envelope`),
+      then ``cache_key`` then ``delta_against``, each as
+      ``Option<String>`` (one byte tag 0/1 + length-prefixed UTF-8 when
+      present).
+    """
+
+    version: int  # WIRE_VERSION_V2
+    job_id: str
+    tenant_id: str
+    callable: bytes
+    args: bytes
+    hmac: bytes  # 32 bytes
+    resource_limits: ResourceLimits = field(
+        default_factory=lambda: ResourceLimits(1.0, 1024, 0, 60)
+    )
+    cache_key: str | None = None
+    delta_against: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.version != WIRE_VERSION_V2:
+            raise UnknownWireVersionError(
+                f"EnvelopeV2.version must be V2 ({WIRE_VERSION_V2}), got {self.version}"
+            )
+        if len(self.hmac) != 32:
+            raise WireDecodeError(f"hmac must be 32 bytes, got {len(self.hmac)}")
+        if not isinstance(self.callable, (bytes, bytearray)):
+            raise WireDecodeError("callable must be bytes")
+        if not isinstance(self.args, (bytes, bytearray)):
+            raise WireDecodeError("args must be bytes")
+        self.resource_limits.validate()
+
+
+@dataclass(frozen=True)
+class ChunkFrame:
+    """One frame in a multi-chunk streaming dispatch (#175).
+
+    Logical large payloads (multi-GB state-dicts) are split across
+    ``ChunkFrame``s. Each carries the same ``stream_id``, a 0-indexed
+    monotonic ``seq``, a ``last`` marker on the final frame, and the
+    payload bytes. Concatenation of every ``bytes_`` field in ``seq``
+    order yields the postcard-encoded :class:`EnvelopeV2`.
+    """
+
+    version: int  # WIRE_VERSION_V2
+    stream_id: int
+    seq: int
+    last: bool
+    bytes_: bytes
+
+    def __post_init__(self) -> None:
+        if self.version != WIRE_VERSION_V2:
+            raise UnknownWireVersionError("ChunkFrame.version must be V2")
+        if self.stream_id < 0 or self.stream_id > 0xFFFF_FFFF_FFFF_FFFF:
+            raise WireDecodeError(f"stream_id out of range: {self.stream_id}")
+        if self.seq < 0 or self.seq > 0xFFFF_FFFF:
+            raise WireDecodeError(f"seq out of range: {self.seq}")
+
+
+# ---- v0.2 codec helpers ------------------------------------------------------
+
+
+def _append_option_string(out: bytearray, value: str | None) -> None:
+    """Postcard Option<String>: 0x00 = None; 0x01 + length-prefixed UTF-8."""
+    if value is None:
+        out.append(0x00)
+        return
+    out.append(0x01)
+    _append_string(out, value)
+
+
+def _read_option_string(buf: memoryview, offset: int) -> tuple[str | None, int]:
+    if offset >= len(buf):
+        raise WireDecodeError("Option<String> tag truncated")
+    tag = buf[offset]
+    offset += 1
+    if tag == 0:
+        return None, offset
+    if tag != 1:
+        raise WireDecodeError(f"unexpected Option<String> tag: {tag}")
+    return _read_string(buf, offset)
+
+
+def encode_envelope_v2(env: EnvelopeV2) -> bytes:
+    """Serialise an :class:`EnvelopeV2` into postcard bytes."""
+    if env.version != WIRE_VERSION_V2:
+        raise WireDecodeError(f"unsupported wire version: {env.version}")
+    out = bytearray()
+    out.append(WIRE_VERSION_V2)
+    _append_string(out, env.job_id)
+    _append_string(out, env.tenant_id)
+    _append_bytes(out, env.callable)
+    _append_bytes(out, env.args)
+    if len(env.hmac) != 32:
+        raise WireDecodeError("hmac must be 32 bytes")
+    out.extend(env.hmac)
+    out.extend(struct.pack("<f", env.resource_limits.cpus))
+    out.extend(_enc_varint(env.resource_limits.memory_mb))
+    out.extend(_enc_varint(env.resource_limits.gpus))
+    out.extend(_enc_varint(env.resource_limits.timeout_seconds))
+    _append_option_string(out, env.cache_key)
+    _append_option_string(out, env.delta_against)
+    return bytes(out)
+
+
+def decode_envelope_v2(raw: bytes) -> EnvelopeV2:
+    """Parse postcard bytes into an :class:`EnvelopeV2`. Raises on malformed input."""
+    buf = memoryview(raw)
+    if not buf:
+        raise WireDecodeError("empty envelope")
+    version = buf[0]
+    if version != WIRE_VERSION_V2:
+        raise UnknownWireVersionError(f"expected V2 envelope; got version {version}")
+    offset = 1
+    job_id, offset = _read_string(buf, offset)
+    tenant_id, offset = _read_string(buf, offset)
+    callable_bytes, offset = _read_bytes(buf, offset)
+    args, offset = _read_bytes(buf, offset)
+    if offset + 32 > len(buf):
+        raise WireDecodeError("hmac truncated")
+    hmac_bytes = bytes(buf[offset : offset + 32])
+    offset += 32
+    if offset + 4 > len(buf):
+        raise WireDecodeError("cpus (f32) truncated")
+    cpus = struct.unpack_from("<f", buf, offset)[0]
+    offset += 4
+    memory_mb, offset = _dec_varint(buf, offset)
+    gpus, offset = _dec_varint(buf, offset)
+    timeout_seconds, offset = _dec_varint(buf, offset)
+    cache_key, offset = _read_option_string(buf, offset)
+    delta_against, offset = _read_option_string(buf, offset)
+    if offset != len(buf):
+        raise WireDecodeError(f"trailing bytes after EnvelopeV2: {len(buf) - offset}")
+    return EnvelopeV2(
+        version=version,
+        job_id=job_id,
+        tenant_id=tenant_id,
+        callable=callable_bytes,
+        args=args,
+        hmac=hmac_bytes,
+        resource_limits=ResourceLimits(
+            cpus=float(cpus),
+            memory_mb=int(memory_mb),
+            gpus=int(gpus),
+            timeout_seconds=int(timeout_seconds),
+        ),
+        cache_key=cache_key,
+        delta_against=delta_against,
+    )
+
+
+def encode_chunk_frame(c: ChunkFrame) -> bytes:
+    """Serialise a :class:`ChunkFrame` into postcard bytes."""
+    if c.version != WIRE_VERSION_V2:
+        raise WireDecodeError(f"unsupported wire version: {c.version}")
+    out = bytearray()
+    out.append(WIRE_VERSION_V2)
+    out.extend(_enc_varint(c.stream_id))
+    out.extend(_enc_varint(c.seq))
+    out.append(0x01 if c.last else 0x00)
+    _append_bytes(out, c.bytes_)
+    return bytes(out)
+
+
+def decode_chunk_frame(raw: bytes) -> ChunkFrame:
+    """Parse postcard bytes into a :class:`ChunkFrame`."""
+    buf = memoryview(raw)
+    if not buf:
+        raise WireDecodeError("empty chunk frame")
+    version = buf[0]
+    if version != WIRE_VERSION_V2:
+        raise UnknownWireVersionError(f"expected V2 chunk; got version {version}")
+    offset = 1
+    stream_id, offset = _dec_varint_u64(buf, offset)
+    seq, offset = _dec_varint(buf, offset)
+    if offset >= len(buf):
+        raise WireDecodeError("last-flag truncated")
+    last = buf[offset]
+    offset += 1
+    if last not in (0, 1):
+        raise WireDecodeError(f"invalid last-flag: {last}")
+    payload, offset = _read_bytes(buf, offset)
+    if offset != len(buf):
+        raise WireDecodeError(f"trailing bytes after ChunkFrame: {len(buf) - offset}")
+    return ChunkFrame(
+        version=version,
+        stream_id=int(stream_id),
+        seq=int(seq),
+        last=bool(last),
+        bytes_=payload,
+    )
+
+
 __all__ = [
+    "ChunkFrame",
     "Envelope",
+    "EnvelopeV2",
     "HmacMismatchError",
     "ResourceLimits",
     "UnknownWireVersionError",
     "WIRE_VERSION_V1",
+    "WIRE_VERSION_V2",
     "WireDecodeError",
     "WireError",
     "compute_hmac",
+    "decode_chunk_frame",
     "decode_envelope",
+    "decode_envelope_v2",
+    "encode_chunk_frame",
     "encode_envelope",
+    "encode_envelope_v2",
     "safe_loads",
     "verify_hmac",
 ]


### PR DESCRIPTION
## Summary

Closes #174 and #175 **Phase 1** (substrate). Worker-side reassembly + delta-apply lands as a separate Phase 2 PR.

Postcard is positional, so adding fields to `Envelope` would have broken v0.1 byte-compat. Instead this PR introduces **three new types alongside** the existing v0.1 surface:

- `EnvelopeV2` — adds `cache_key: Option<String>` + `delta_against: Option<String>` (#174 state-dict delta encoding).
- `ChunkFrame` — `{ version, stream_id (u64), seq (u32), last (bool), bytes }` for #175 multi-chunk streaming.
- `V2Message` — top-level enum `{ Envelope(EnvelopeV2), Chunk(ChunkFrame) }`.

Crate version: **`zakuro-wire` 0.1.0 → 0.2.0**.

Mirror in Python under `zakuro/wire/`. Both sides + RFC 0001 amendment.

## Backwards/forwards-compat matrix

| broker | worker | outcome |
|---|---|---|
| v0.1 | v0.1 | unchanged, byte-identical |
| v0.1 | v0.2 | works — v0.2 worker still decodes v0.1 envelopes |
| v0.2 | v0.1 | worker rejects with `UnknownWireVersion`; broker falls back to v0.1 per `/info`-advertised wire-version (advisory today, enforced in Phase 2) |
| v0.2 | v0.2 | full v0.2 path with deltas + chunks |

A regression test (`v1_envelope_first_byte_unchanged`) asserts the v0.1 first byte is still `0x00` — guard against accidentally perturbing v0.1 byte layout.

## Test plan

- [x] `cargo test -p zakuro-wire` → 10 inline + 4 snapshot + 1 doc = 15 passed.
- [x] `pytest tests/wire/` → 37 passed (23 v0.1 + 14 v0.2).
- [x] Full suite: 207 passed.
- [x] `ruff check` / `ruff format --check` clean.
- [x] `mkdocs build --strict` passes with the RFC 0001 amendment.
- [ ] CI green.

## Phase 2 — what's next

A separate PR wires the worker side:
1. `EnvelopeV2`-aware `unwrap_payload` (gated on `ZAKURO_WIRE=v2`).
2. Worker LRU cache (`ZAKURO_CACHE_MAX_ENTRIES` / `ZAKURO_CACHE_MAX_BYTES`).
3. Delta-apply against the cached value when `delta_against = Some(...)`.
4. ChunkFrame reassembly buffer (per `stream_id`, ordered by `seq`, triggered on `last=true`).
5. Cache-miss reply: `WorkerUnavailable { reason: "cache_miss" }` → broker retries with full payload.

## Cross-repo

Paired zc PR required: zc must adopt `zakuro-wire = 0.2.0` to interop on the new path. Until that lands, `EnvelopeV2` / `ChunkFrame` round-trip cleanly but neither the broker nor the worker exercises the new fields. v0.1 traffic continues working unchanged.

Branch has PR #188 (wire v0.1 substrate) merged in for testing. When that lands on master, rebase is trivial.