### PR TITLE
ci: install [worker] + [observability] extras in the Test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,14 @@ jobs:
         uses: arduino/setup-task@v2
 
       - name: Install dependencies
-        run: uv pip install -e ".[dev]" --system
+        # Install [dev] + the optional dep families that the test suite
+        # imports. Without [worker] / [observability] the worker server's
+        # module-level imports (fastapi, sentry-sdk, structlog,
+        # prometheus_client, opentelemetry-sdk, PyJWT, aioquic) trip the
+        # import chain at collection time even though individual tests
+        # use pytest.importorskip — the importskip only protects the
+        # test file, not the production module the test imports.
+        run: uv pip install -e ".[dev,worker,observability]" --system
 
       - name: Run linting
         run: task ci:lint
@@ -60,7 +67,9 @@ jobs:
         uses: arduino/setup-task@v2
 
       - name: Install dependencies
-        run: uv pip install -e ".[dev]" --system
+        # Same extras as the test job — mypy needs to see the optional
+        # dep modules to type-check the worker server's imports.
+        run: uv pip install -e ".[dev,worker,observability]" --system
 
       - name: Run type checking (report-only)
         run: task ci:typecheck || true


### PR DESCRIPTION
## Summary

Tier C fix from the PR-review rollup. Three open PRs were failing `test (3.11)` because:

- Their production modules (`zakuro.observability.metrics`, `zakuro.observability.tracing`, `zakuro.auth.jwt`, `zakuro.worker.server`) have module-top imports of optional deps in `[worker]` / `[observability]`.
- The Test workflow installs only `[dev]`, so those imports fire at pytest collection time and the test file crashes before `importorskip` can run.

## Fix

`.github/workflows/test.yml`:
- Test job: `uv pip install -e ".[dev]"` → `uv pip install -e ".[dev,worker,observability]"`
- Typecheck job: same — mypy needs the optional packages to type-check the worker server's imports.

## After this lands

Rebase #185 (Prometheus), #186 (OTel), and #193 (JWT auth wiring) onto master and their `test (3.11)` / `test (3.12)` failures clear.

## Test plan

- [x] Local `pytest tests/` still 170+ passes (no changes to test files).
- [x] No new lints / type errors introduced.
- [ ] CI green on this PR (one matrix line per Python version installs the extra and runs the same tests; pip-install time +~30 s per job).