### PR TITLE
feat(quic): wire ChunkReassembler into worker QUIC handler (#175 Phase 3)

### DIFF
--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -38,11 +38,12 @@ Response frame (server → client):
 
 ### 2.1 Opcodes
 
-| op | name    | request payload                                | response payload (stat=0)                |
-|----|---------|------------------------------------------------|------------------------------------------|
-| 1  | EXECUTE | cloudpickle of `{"func", "args", "kwargs"}`   | cloudpickle of `result` (may be `Exception`) |
-| 2  | INFO    | empty (`length = 0`)                           | UTF-8 JSON — see §4                      |
-| 3  | HEALTH  | empty (`length = 0`)                           | UTF-8 JSON `{"status":"ok"}`             |
+| op | name          | request payload                                | response payload (stat=0)                |
+|----|---------------|------------------------------------------------|------------------------------------------|
+| 1  | EXECUTE       | cloudpickle of `{"func", "args", "kwargs"}`   | cloudpickle of `result` (may be `Exception`) |
+| 2  | INFO          | empty (`length = 0`)                           | UTF-8 JSON — see §4                      |
+| 3  | HEALTH        | empty (`length = 0`)                           | UTF-8 JSON `{"status":"ok"}`             |
+| 4  | EXECUTE_CHUNK | postcard `ChunkFrame` — one chunk of a v0.2 multi-chunk dispatch (RFC 0001 amendment). Multiple chunks share a `ChunkFrame.stream_id`; final chunk has `last=true`. Concatenated bytes are a v0.2 `EnvelopeV2`. | non-final chunk: empty (`stat = 3` ack). Final chunk: cloudpickle of `result` (per EXECUTE). |
 
 Unknown opcodes MUST produce `stat = 2` (see below) with a UTF-8 payload describing the error.
 
@@ -53,6 +54,7 @@ Unknown opcodes MUST produce `stat = 2` (see below) with a UTF-8 payload describ
 | 0    | OK. `payload` is the successful response per the opcode.               |
 | 1    | User error — the function ran and raised. `payload` is the cloudpickled `Exception` for EXECUTE; for other opcodes this status MUST NOT be used. |
 | 2    | Protocol / server error — malformed frame, unknown opcode, worker overload. `payload` is UTF-8 text. |
+| 3    | Chunk accepted, more chunks expected. Used only by `EXECUTE_CHUNK` (op=4) for non-final chunks. `payload` is empty. The caller continues sending chunks on new QUIC streams sharing the same `ChunkFrame.stream_id`. |
 
 Rationale: separating `stat=1` (a successful RPC that returned a user exception) from `stat=2` (transport/protocol failure) lets the caller distinguish "function on worker raised" from "worker itself is broken," without requiring the caller to cloudpickle-probe every response.
 

--- a/tests/wire/test_quic_chunk_handler.py
+++ b/tests/wire/test_quic_chunk_handler.py
@@ -1,0 +1,226 @@
+"""Phase-3 wiring tests for the QUIC chunk handler (#175)."""
+
+from __future__ import annotations
+
+import asyncio
+from concurrent.futures import ThreadPoolExecutor
+
+import cloudpickle
+import pytest
+
+from zakuro.wire import (
+    WIRE_VERSION_V2,
+    ChunkFrame,
+    EnvelopeV2,
+    ResourceLimits,
+    encode_chunk_frame,
+    encode_envelope_v2,
+)
+
+pytest.importorskip("aioquic")
+
+from zakuro.worker.quic_server import (  # noqa: E402  -- aioquic must be importable first
+    STAT_CHUNK_ACK,
+    STAT_OK,
+    STAT_PROTOCOL_ERROR,
+    WorkerQuicProtocol,
+)
+
+
+def _build_envelope_v2(callable_blob: bytes, *, tenant: str = "tenant-acme") -> EnvelopeV2:
+    return EnvelopeV2(
+        version=WIRE_VERSION_V2,
+        job_id="j-1",
+        tenant_id=tenant,
+        callable=callable_blob,
+        args=b"",
+        hmac=b"\x00" * 32,
+        resource_limits=ResourceLimits(cpus=1.0, memory_mb=1024, gpus=0, timeout_seconds=30),
+    )
+
+
+def _instantiate_protocol() -> WorkerQuicProtocol:
+    """Build a WorkerQuicProtocol skipping aioquic's base constructor.
+
+    Going through aioquic's full QuicConnectionProtocol() requires a real
+    QuicConnection + asyncio loop wiring we don't need for the chunk-handler
+    unit tests. We bypass __init__ and set just the fields _handle_chunk reads.
+    """
+    proto = WorkerQuicProtocol.__new__(WorkerQuicProtocol)
+    proto._executor = ThreadPoolExecutor(max_workers=1)
+    from zakuro.wire.streaming import ChunkReassembler
+
+    proto._reassembler = ChunkReassembler()
+    return proto
+
+
+# ---- happy path -------------------------------------------------------------
+
+
+def test_chunked_dispatch_round_trips() -> None:
+    """Multi-chunk envelope reassembles and the executor runs the callable."""
+
+    def double(x: int) -> int:
+        return x * 2
+
+    callable_blob = cloudpickle.dumps({"action": "execute", "func": double, "args": (21,)})
+    env_bytes = encode_envelope_v2(_build_envelope_v2(callable_blob))
+
+    # Split into 3 chunks
+    chunks = []
+    chunk_size = max(1, len(env_bytes) // 3)
+    for i, start in enumerate(range(0, len(env_bytes), chunk_size)):
+        slice_ = env_bytes[start : start + chunk_size]
+        is_last = (start + chunk_size) >= len(env_bytes)
+        chunks.append(
+            ChunkFrame(
+                version=WIRE_VERSION_V2,
+                stream_id=42,
+                seq=i,
+                last=is_last,
+                bytes_=slice_,
+            )
+        )
+
+    proto = _instantiate_protocol()
+
+    async def run() -> list[tuple[int, bytes]]:
+        return [await proto._handle_chunk(encode_chunk_frame(c)) for c in chunks]
+
+    results = asyncio.run(run())
+
+    # Intermediates → CHUNK_ACK + empty body
+    for status, body in results[:-1]:
+        assert status == STAT_CHUNK_ACK
+        assert body == b""
+
+    # Final → executor produced cloudpickle(42)
+    status, body = results[-1]
+    assert status == STAT_OK
+    assert cloudpickle.loads(body) == 42
+
+
+def test_single_chunk_dispatch() -> None:
+    """A single-chunk dispatch (last=True on seq=0) executes immediately."""
+
+    def square(x: int) -> int:
+        return x * x
+
+    callable_blob = cloudpickle.dumps({"action": "execute", "func": square, "args": (9,)})
+    env_bytes = encode_envelope_v2(_build_envelope_v2(callable_blob))
+    chunk = ChunkFrame(version=WIRE_VERSION_V2, stream_id=1, seq=0, last=True, bytes_=env_bytes)
+
+    proto = _instantiate_protocol()
+    status, body = asyncio.run(proto._handle_chunk(encode_chunk_frame(chunk)))
+    assert status == STAT_OK
+    assert cloudpickle.loads(body) == 81
+
+
+# ---- error paths ------------------------------------------------------------
+
+
+def test_malformed_chunk_payload_rejected() -> None:
+    proto = _instantiate_protocol()
+    status, body = asyncio.run(proto._handle_chunk(b"\xff\xff\xff garbage"))
+    assert status == STAT_PROTOCOL_ERROR
+    assert b"malformed chunk" in body
+
+
+def test_out_of_order_chunks_rejected() -> None:
+    """A chunk with seq=5 when seq=0 is expected is rejected protocol-error."""
+    proto = _instantiate_protocol()
+    chunk = ChunkFrame(version=WIRE_VERSION_V2, stream_id=1, seq=5, last=False, bytes_=b"x")
+    status, body = asyncio.run(proto._handle_chunk(encode_chunk_frame(chunk)))
+    assert status == STAT_PROTOCOL_ERROR
+    assert b"chunk rejected" in body
+
+
+def test_assembled_garbage_rejected_as_envelope() -> None:
+    """A stream whose reassembled bytes are not a valid EnvelopeV2 → 401-ish protocol error."""
+    proto = _instantiate_protocol()
+    chunks = [
+        ChunkFrame(version=WIRE_VERSION_V2, stream_id=7, seq=0, last=False, bytes_=b"hello"),
+        ChunkFrame(version=WIRE_VERSION_V2, stream_id=7, seq=1, last=True, bytes_=b"world"),
+    ]
+
+    async def run() -> list[tuple[int, bytes]]:
+        return [await proto._handle_chunk(encode_chunk_frame(c)) for c in chunks]
+
+    results = asyncio.run(run())
+    final_status, final_body = results[-1]
+    assert final_status == STAT_PROTOCOL_ERROR
+    assert b"reassembled envelope malformed" in final_body
+
+
+def test_concurrent_streams_isolated() -> None:
+    """Two interleaved stream_ids don't poison each other's reassembly."""
+
+    def f_a(_: int) -> int:
+        return 10
+
+    def f_b(_: int) -> int:
+        return 20
+
+    env_a = encode_envelope_v2(
+        _build_envelope_v2(cloudpickle.dumps({"action": "execute", "func": f_a, "args": (0,)}))
+    )
+    env_b = encode_envelope_v2(
+        _build_envelope_v2(cloudpickle.dumps({"action": "execute", "func": f_b, "args": (0,)}))
+    )
+
+    proto = _instantiate_protocol()
+
+    async def run() -> tuple[tuple[int, bytes], tuple[int, bytes]]:
+        # Send first half of each, then second half (interleaved)
+        await proto._handle_chunk(
+            encode_chunk_frame(
+                ChunkFrame(
+                    version=WIRE_VERSION_V2,
+                    stream_id=100,
+                    seq=0,
+                    last=False,
+                    bytes_=env_a[: len(env_a) // 2],
+                )
+            )
+        )
+        await proto._handle_chunk(
+            encode_chunk_frame(
+                ChunkFrame(
+                    version=WIRE_VERSION_V2,
+                    stream_id=200,
+                    seq=0,
+                    last=False,
+                    bytes_=env_b[: len(env_b) // 2],
+                )
+            )
+        )
+        # Final halves
+        result_a = await proto._handle_chunk(
+            encode_chunk_frame(
+                ChunkFrame(
+                    version=WIRE_VERSION_V2,
+                    stream_id=100,
+                    seq=1,
+                    last=True,
+                    bytes_=env_a[len(env_a) // 2 :],
+                )
+            )
+        )
+        result_b = await proto._handle_chunk(
+            encode_chunk_frame(
+                ChunkFrame(
+                    version=WIRE_VERSION_V2,
+                    stream_id=200,
+                    seq=1,
+                    last=True,
+                    bytes_=env_b[len(env_b) // 2 :],
+                )
+            )
+        )
+        return result_a, result_b
+
+    result_a, result_b = asyncio.run(run())
+    assert result_a[0] == STAT_OK
+    assert result_b[0] == STAT_OK
+    assert cloudpickle.loads(result_a[1]) == 10
+    assert cloudpickle.loads(result_b[1]) == 20

--- a/zakuro/worker/quic_server.py
+++ b/zakuro/worker/quic_server.py
@@ -39,10 +39,19 @@ logger = logging.getLogger(__name__)
 OP_EXECUTE = 1
 OP_INFO = 2
 OP_HEALTH = 3
+# Streaming chunk for a multi-chunk dispatch (RFC 0001 amendment, #175).
+# Each frame carries one ChunkFrame; the worker reassembles in order via
+# zakuro.wire.streaming.ChunkReassembler and treats the concatenated bytes
+# as a v0.2 EnvelopeV2 once last=True arrives.
+OP_EXECUTE_CHUNK = 4
 
 STAT_OK = 0
 STAT_USER_ERROR = 1
 STAT_PROTOCOL_ERROR = 2
+# A chunk was accepted but more chunks are expected before the stream
+# can be assembled. The caller continues sending chunks; only when the
+# final chunk arrives does the worker emit OK + the execution body.
+STAT_CHUNK_ACK = 3
 
 ALPN = ["zk-worker"]
 DEFAULT_PORT = 4433
@@ -157,13 +166,25 @@ class _StreamBuffer:
 class WorkerQuicProtocol(QuicConnectionProtocol):
     """One instance per accepted QUIC connection.
 
-    Streams are independent; each carries exactly one request/response pair.
+    QUIC streams are independent; the *framing* layer (this protocol)
+    treats each stream as carrying exactly one request/response pair.
+
+    Multi-chunk dispatches (#175 Phase 3) span multiple QUIC streams
+    that share a single logical ``ChunkFrame.stream_id``. The per-
+    connection :class:`ChunkReassembler` accumulates them; the *final*
+    chunk's QUIC stream is the one that carries the execution result.
     """
 
     def __init__(self, *args: Any, executor: ThreadPoolExecutor, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self._executor = executor
         self._streams: dict[int, _StreamBuffer] = {}
+        # Lazy import: zakuro.wire.streaming pulls in serde_bytes types that
+        # are not needed for v0.1 traffic. Importing here keeps the
+        # module-load cost honest for v0.1-only deployments.
+        from zakuro.wire.streaming import ChunkReassembler
+
+        self._reassembler = ChunkReassembler()
 
     def quic_event_received(self, event: Any) -> None:
         if isinstance(event, StreamDataReceived):
@@ -178,6 +199,8 @@ class WorkerQuicProtocol(QuicConnectionProtocol):
             if op == OP_EXECUTE:
                 loop = asyncio.get_event_loop()
                 status, body = await loop.run_in_executor(self._executor, _execute_payload, payload)
+            elif op == OP_EXECUTE_CHUNK:
+                status, body = await self._handle_chunk(payload)
             elif op == OP_INFO:
                 status, body = STAT_OK, _info_payload()
             elif op == OP_HEALTH:
@@ -193,6 +216,47 @@ class WorkerQuicProtocol(QuicConnectionProtocol):
 
         self._quic.send_stream_data(stream_id, _frame(status, body), end_stream=True)
         self.transmit()
+
+    async def _handle_chunk(self, payload: bytes) -> tuple[int, bytes]:
+        """Decode a ChunkFrame, feed the reassembler, dispatch on last=True.
+
+        Returns:
+            ``(STAT_CHUNK_ACK, b"")`` while more chunks are expected.
+            ``(STAT_OK, body)`` on the final chunk after execution finishes.
+            ``(STAT_PROTOCOL_ERROR, reason)`` on malformed / out-of-order
+            chunks or on rejected reassembled envelopes.
+        """
+        # Deferred imports for the same reason as the reassembler in __init__.
+        from zakuro.wire import (
+            WireError,
+            decode_chunk_frame,
+            decode_envelope_v2,
+        )
+        from zakuro.wire.streaming import StreamingError
+
+        try:
+            chunk = decode_chunk_frame(payload)
+        except WireError as exc:
+            return STAT_PROTOCOL_ERROR, f"malformed chunk: {exc!r}".encode()
+
+        try:
+            assembled = self._reassembler.feed(chunk)
+        except StreamingError as exc:
+            return STAT_PROTOCOL_ERROR, f"chunk rejected: {exc!r}".encode()
+
+        if assembled is None:
+            # Intermediate chunk — ack only, no execution yet.
+            return STAT_CHUNK_ACK, b""
+
+        # Final chunk: assembled bytes are a postcard EnvelopeV2. Decode +
+        # forward the callable to the executor exactly like v0.1.
+        try:
+            envelope_v2 = decode_envelope_v2(assembled)
+        except WireError as exc:
+            return STAT_PROTOCOL_ERROR, f"reassembled envelope malformed: {exc!r}".encode()
+
+        loop = asyncio.get_event_loop()
+        return await loop.run_in_executor(self._executor, _execute_payload, envelope_v2.callable)
 
 
 def _ensure_certificate() -> tuple[Path, Path]:


### PR DESCRIPTION
## Summary

Closes #175 **Phase 3** (the QUIC wiring on top of Phase 2's reassembler).

- New opcode **`OP_EXECUTE_CHUNK = 4`** and status **`STAT_CHUNK_ACK = 3`** in the QUIC framing.
- `WorkerQuicProtocol` carries a per-connection `ChunkReassembler`.
- `_handle_chunk(payload)` decodes the ChunkFrame, feeds the reassembler, and on `last=True` decodes the concatenated bytes as a v0.2 `EnvelopeV2` and forwards the callable to `_execute_payload` (same path as `OP_EXECUTE`).
- Lazy import of `zakuro.wire.streaming` so v0.1-only deployments don't pay the load cost.
- `docs/PROTOCOL.md` updated with the new opcode + status row.

## Behaviour matrix

| chunk arrival | server response |
|---|---|
| non-final, in-order | `STAT_CHUNK_ACK = 3` + empty body |
| final, in-order, valid envelope | `STAT_OK` + cloudpickled result |
| out-of-order seq | `STAT_PROTOCOL_ERROR` + reason (stream dropped) |
| malformed ChunkFrame | `STAT_PROTOCOL_ERROR` + reason |
| reassembled bytes aren't a valid EnvelopeV2 | `STAT_PROTOCOL_ERROR` + reason |

## Test plan

- [x] `pytest tests/wire/test_quic_chunk_handler.py` → 6 passed: multi-chunk round-trip, single-chunk, malformed-chunk, out-of-order, garbage-reassembly, two-concurrent-streams-isolated.
- [x] Full suite: 289 passed.
- [x] `ruff check` / `ruff format --check` clean.
- [ ] CI green.

## Cross-repo

**Paired zc PR needed** for production rollout: the broker side must learn to fragment large `EnvelopeV2` into `OP_EXECUTE_CHUNK` frames when the worker advertises v0.2 support. Until that lands, this path runs only via direct test invocations.