### PR TITLE
feat(wire): PayloadCache + bsdiff4 delta-apply (#174 Phase 2 substrate)

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -59,7 +59,8 @@ Python runtime dependencies
 --- Apache-2.0 OR BSD-3-Clause (1 package(s)) ---
   * cryptography 46.0.7  <https://github.com/pyca/cryptography>
 
---- BSD (1 package(s)) ---
+--- BSD (2 package(s)) ---
+  * bsdiff4 1.2.6  <https://github.com/ilanschnell/bsdiff4>
   * partd 1.4.2  <http://github.com/dask/partd/>
 
 --- BSD License (10 package(s)) ---

--- a/docs/rfcs/0001-wire-format-postcard.md
+++ b/docs/rfcs/0001-wire-format-postcard.md
@@ -126,9 +126,33 @@ v0.2 introduces three new types alongside (not replacing) the v0.1 `Envelope`. v
 
 Cache lives on the worker, bounded by an LRU of N entries × cap-per-entry, both configurable via `ZAKURO_CACHE_MAX_ENTRIES` / `ZAKURO_CACHE_MAX_BYTES`. Defaults: 32 entries / 4 GB. Eviction is silent — callers that suffer a cache-miss on a delta retry with the full payload, which is the same code path as never having cached.
 
-### Phase 2 follow-up
+Implementation: [`zakuro.wire.cache.PayloadCache`](https://github.com/zakuro-ai/zakuro/blob/master/zakuro/wire/cache.py) (an ordered-dict LRU; promotes on `get`; evicts oldest entry on either cap violation; refuses to admit a single value larger than the bytes budget).
 
-This PR ships the schema substrate only. The worker-side reassembly + delta-apply logic lands as a Phase 2 PR (mirroring the #115 / #116 / #117 substrate-vs-wiring split). Until that lands, v0.2 envelopes round-trip through the schema cleanly but the worker treats `cache_key` / `delta_against` as advisory metadata.
+### Delta-apply algorithm
+
+The wire crate carries `callable` bytes opaquely. When `delta_against = Some(prev_key)`, the worker reconstructs:
+
+```python
+full = bsdiff4.patch(cache[prev_key], envelope.callable)
+```
+
+**Format choice: bsdiff4.** Reasoning:
+
+- It's well-established (the format `bsdiff`+`bspatch` use, in production since 2003).
+- `bsdiff4` ships as a pure-Python lib with a tiny C accelerator; <50 KB wheel.
+- It produces meaningfully smaller deltas than `zstd --train` for binary state-dicts where most bytes carry small numeric changes (the common case in fine-tuning).
+- It's *not* tensor-aware — a future tensor-aware diff (e.g. quantised-residual or low-rank delta) could supplant it. When that happens we add a `delta_format: Option<DeltaFormat>` field to EnvelopeV2 and gate selection on it. For v0.2 we hard-code bsdiff4.
+
+The delta isn't authenticated by itself: the HMAC over `(callable, args, job_id)` in the envelope covers the *delta bytes* as they arrive. A reconstructed payload that doesn't match the broker's intent produces a different HMAC than the broker computed, so `safe_loads` rejects with `HmacMismatchError` before the bytes reach cloudpickle. The cache layer is not the security boundary.
+
+### Phase 2 substrate (current) vs Phase 2 wiring (next)
+
+The substrate ships in two slices:
+
+1. **Substrate (this PR / #174 Phase 2 substrate):** `zakuro/wire/cache.py` with `PayloadCache` LRU + `apply_delta` (bsdiff4). 15 unit tests. Module is standalone; no worker integration yet.
+2. **Wiring (next PR, after #200 lands):** the QUIC handler's `_handle_chunk` calls `cache.get(env.delta_against)` + `apply_delta` before forwarding to the executor; `cache.put(env.cache_key, callable_bytes)` after successful dispatch. Cache miss / DeltaApplyError surface as `WorkerUnavailable { reason: "cache_miss" }` so the broker retries with the full payload.
+
+This split mirrors the #115 / #116 / #117 substrate-vs-wiring pattern: the substrate has its own narrow tests; the wiring exercises the end-to-end flow.
 
 ### Cross-repo
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,11 @@ worker = [
     # PyJWT for Ed25519 JWT verification (RFC 0002, #116). The cryptography
     # extra pulls in pyca/cryptography needed for asymmetric algorithms.
     "PyJWT[crypto]>=2.8.0",
+    # bsdiff4 for state-dict delta encoding (RFC 0001 amendment, #174).
+    # The worker uses bsdiff4.patch(cached, delta) -> full_payload when an
+    # incoming envelope's delta_against is set. Pure-Python fallback ships
+    # with the package; the C extension speeds it up when available.
+    "bsdiff4>=1.2.4",
 ]
 ray = ["ray>=2.0.0"]
 dask = ["dask>=2023.0.0", "distributed>=2023.0.0"]

--- a/tests/wire/test_cache.py
+++ b/tests/wire/test_cache.py
@@ -1,0 +1,156 @@
+"""Unit tests for the v0.2 payload cache + delta-apply (#174 Phase 2 substrate)."""
+
+from __future__ import annotations
+
+import pytest
+
+from zakuro.wire.cache import (
+    CacheError,
+    CacheMissError,
+    DeltaApplyError,
+    PayloadCache,
+    apply_delta,
+)
+
+# ---- PayloadCache contract --------------------------------------------------
+
+
+def test_put_then_get_round_trips() -> None:
+    cache = PayloadCache(max_entries=4, max_bytes=1024)
+    cache.put("epoch-1", b"state-dict-bytes")
+    assert cache.get("epoch-1") == b"state-dict-bytes"
+    assert cache.has("epoch-1")
+
+
+def test_get_raises_on_miss() -> None:
+    cache = PayloadCache(max_entries=4, max_bytes=1024)
+    with pytest.raises(CacheMissError, match="epoch-0"):
+        cache.get("epoch-0")
+
+
+def test_lru_evicts_oldest_when_entries_full() -> None:
+    cache = PayloadCache(max_entries=2, max_bytes=1024)
+    cache.put("a", b"AAA")
+    cache.put("b", b"BBB")
+    cache.put("c", b"CCC")  # evicts "a"
+    assert not cache.has("a")
+    assert cache.has("b")
+    assert cache.has("c")
+    assert cache.entries == 2
+
+
+def test_lru_evicts_when_bytes_budget_exceeded() -> None:
+    cache = PayloadCache(max_entries=10, max_bytes=10)
+    cache.put("a", b"AAAA")  # 4 bytes
+    cache.put("b", b"BBBB")  # 4 bytes; total 8 OK
+    cache.put("c", b"CCCC")  # 4 bytes → total 12 > 10 → evict "a"
+    assert not cache.has("a")
+    assert cache.bytes_in_use == 8
+
+
+def test_get_promotes_entry_to_mru() -> None:
+    cache = PayloadCache(max_entries=2, max_bytes=1024)
+    cache.put("a", b"AAA")
+    cache.put("b", b"BBB")
+    # Touch "a" → now "b" is LRU
+    cache.get("a")
+    cache.put("c", b"CCC")  # should evict "b" not "a"
+    assert cache.has("a")
+    assert not cache.has("b")
+
+
+def test_put_same_key_updates_value_not_entry_count() -> None:
+    cache = PayloadCache(max_entries=4, max_bytes=1024)
+    cache.put("a", b"v1")
+    cache.put("a", b"v2")
+    assert cache.entries == 1
+    assert cache.get("a") == b"v2"
+    assert cache.bytes_in_use == 2
+
+
+def test_oversized_single_value_rejected() -> None:
+    cache = PayloadCache(max_entries=10, max_bytes=10)
+    with pytest.raises(CacheError, match="exceeds max_bytes"):
+        cache.put("big", b"x" * 100)
+
+
+def test_drop_removes_entry() -> None:
+    cache = PayloadCache(max_entries=4, max_bytes=1024)
+    cache.put("a", b"AAA")
+    assert cache.drop("a") is True
+    assert cache.drop("a") is False
+    assert not cache.has("a")
+    assert cache.bytes_in_use == 0
+
+
+def test_clear_resets_everything() -> None:
+    cache = PayloadCache(max_entries=4, max_bytes=1024)
+    cache.put("a", b"AAA")
+    cache.put("b", b"BBB")
+    cache.clear()
+    assert cache.entries == 0
+    assert cache.bytes_in_use == 0
+
+
+def test_env_vars_drive_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ZAKURO_CACHE_MAX_ENTRIES", "3")
+    monkeypatch.setenv("ZAKURO_CACHE_MAX_BYTES", "100")
+    cache = PayloadCache()
+    cache.put("a", b"AA")
+    cache.put("b", b"BB")
+    cache.put("c", b"CC")
+    cache.put("d", b"DD")  # exceeds max_entries=3 → evicts "a"
+    assert not cache.has("a")
+    assert cache.entries == 3
+
+
+def test_env_var_garbage_falls_back_to_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ZAKURO_CACHE_MAX_ENTRIES", "not-a-number")
+    cache = PayloadCache()
+    # Falls back to DEFAULT_MAX_ENTRIES = 32
+    assert cache._max_entries == 32  # noqa: SLF001 — test verifies internal
+
+
+def test_constructor_rejects_non_positive_caps() -> None:
+    with pytest.raises(ValueError, match="max_entries"):
+        PayloadCache(max_entries=0, max_bytes=1024)
+    with pytest.raises(ValueError, match="max_bytes"):
+        PayloadCache(max_entries=4, max_bytes=0)
+
+
+# ---- delta apply ------------------------------------------------------------
+
+
+def test_apply_delta_round_trip() -> None:
+    bsdiff4 = pytest.importorskip("bsdiff4")
+    cached = b"a" * 1000 + b"b" * 1000
+    new = b"a" * 1000 + b"c" * 1000  # one section differs
+    delta = bsdiff4.diff(cached, new)
+    reconstructed = apply_delta(cached, delta)
+    assert reconstructed == new
+
+
+def test_apply_delta_is_smaller_than_full_payload() -> None:
+    bsdiff4 = pytest.importorskip("bsdiff4")
+    # 100 KB payload with a tiny change
+    cached = b"x" * 100_000
+    new = b"x" * 99_999 + b"y"
+    delta = bsdiff4.diff(cached, new)
+    assert len(delta) < len(new) // 5, f"delta {len(delta)} should be << {len(new) // 5}"
+    assert apply_delta(cached, delta) == new
+
+
+def test_apply_delta_truncated_input_raises() -> None:
+    """A malformed delta blob raises DeltaApplyError, not a silent corruption."""
+    pytest.importorskip("bsdiff4")
+    with pytest.raises(DeltaApplyError):
+        apply_delta(b"some-cache", b"not-a-valid-bsdiff4-delta-blob")
+
+
+# NOTE: bsdiff4 is lenient by design — applying a valid delta against a
+# *different* base produces garbage rather than raising. That's fine; the
+# wire-format HMAC (RFC 0002) catches it: a reconstructed payload that
+# wasn't built from the expected base produces a different HMAC than the
+# broker computed, so safe_loads rejects with HmacMismatchError before
+# the bytes reach cloudpickle. The cache layer here is intentionally not
+# the security boundary.

--- a/zakuro/wire/cache.py
+++ b/zakuro/wire/cache.py
@@ -1,0 +1,191 @@
+"""Worker-side payload cache for v0.2 state-dict delta encoding (#174 Phase 2).
+
+The wire format (RFC 0001 amendment) carries two new fields on
+:class:`zakuro.wire.EnvelopeV2`:
+
+- ``cache_key`` — when set, the worker stores the reconstructed
+  ``callable`` bytes under this key after the dispatch completes.
+- ``delta_against`` — when set, ``callable`` is a *delta* against the
+  bytes previously cached under this key. The worker reconstructs the
+  full payload via ``bsdiff4.patch(cached, delta)`` before invoking the
+  executor.
+
+This module owns:
+
+* :class:`PayloadCache` — a bounded LRU (by entry count and total bytes)
+  keyed by ``cache_key``.
+* :func:`apply_delta` — the single chokepoint that reconstructs full
+  callable bytes from a cached value + a bsdiff4 delta.
+* :class:`CacheMissError` — raised when ``delta_against`` references a
+  key that's not in the cache. The handler turns this into a wire-level
+  ``WorkerUnavailable { reason: "cache_miss" }`` and the broker retries
+  with the full payload.
+
+Tuning knobs (env vars):
+
+* ``ZAKURO_CACHE_MAX_ENTRIES`` — max distinct cache keys. Default 32.
+* ``ZAKURO_CACHE_MAX_BYTES`` — total bytes budget. Default 4 GiB.
+
+When ``bsdiff4`` is not installed, :func:`apply_delta` raises
+``CacheMissError`` rather than crashing — callers should fall back to
+the full-payload path. The cache itself works without the dep.
+"""
+
+from __future__ import annotations
+
+import os
+from collections import OrderedDict
+from typing import Final
+
+from zakuro.wire import WireError
+
+# Defaults align with the RFC 0001 amendment §"Cache eviction policy".
+DEFAULT_MAX_ENTRIES: Final[int] = 32
+DEFAULT_MAX_BYTES: Final[int] = 4 * 1024 * 1024 * 1024  # 4 GiB
+
+
+class CacheError(WireError):
+    """Base for cache + delta-apply failures."""
+
+
+class CacheMissError(CacheError):
+    """An incoming envelope referenced a cache_key that's not present.
+
+    Surfaced to the broker as ``WorkerUnavailable { reason: "cache_miss" }``
+    so the broker re-dispatches with the full payload.
+    """
+
+
+class DeltaApplyError(CacheError):
+    """``bsdiff4.patch`` raised on the (cached_bytes, delta) pair.
+
+    Usually means the caller computed the delta against a different
+    cache version than the worker has. The recovery path is the same
+    as :class:`CacheMissError`: the broker retries with the full payload.
+    """
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        return default
+    return max(0, value)
+
+
+class PayloadCache:
+    """Bounded LRU cache of reconstructed ``callable`` byte blobs.
+
+    Keyed by the ``cache_key`` from :class:`zakuro.wire.EnvelopeV2`.
+    Entries are evicted on capacity violation (entry-count *or* total
+    bytes); the LRU end is dropped first.
+
+    Single-threaded by design (one cache per worker process). Concurrent
+    callers in the same process must serialise via the worker's existing
+    thread-pool boundary.
+    """
+
+    def __init__(
+        self,
+        *,
+        max_entries: int | None = None,
+        max_bytes: int | None = None,
+    ) -> None:
+        self._max_entries = (
+            max_entries
+            if max_entries is not None
+            else _env_int("ZAKURO_CACHE_MAX_ENTRIES", DEFAULT_MAX_ENTRIES)
+        )
+        self._max_bytes = (
+            max_bytes
+            if max_bytes is not None
+            else _env_int("ZAKURO_CACHE_MAX_BYTES", DEFAULT_MAX_BYTES)
+        )
+        if self._max_entries <= 0:
+            raise ValueError("max_entries must be > 0")
+        if self._max_bytes <= 0:
+            raise ValueError("max_bytes must be > 0")
+        self._store: OrderedDict[str, bytes] = OrderedDict()
+        self._bytes_in_use: int = 0
+
+    @property
+    def entries(self) -> int:
+        return len(self._store)
+
+    @property
+    def bytes_in_use(self) -> int:
+        return self._bytes_in_use
+
+    def get(self, key: str) -> bytes:
+        """Look up *key*. Raises :class:`CacheMissError` on miss.
+
+        Promotes the entry to most-recently-used.
+        """
+        try:
+            value = self._store[key]
+        except KeyError as exc:
+            raise CacheMissError(f"cache miss for key: {key!r}") from exc
+        self._store.move_to_end(key)
+        return value
+
+    def has(self, key: str) -> bool:
+        return key in self._store
+
+    def put(self, key: str, value: bytes) -> None:
+        """Store *value* under *key*. Evicts LRU entries on capacity violation."""
+        # If the value alone exceeds the bytes budget, refuse — we won't
+        # silently drop the entire cache to admit a single oversized blob.
+        if len(value) > self._max_bytes:
+            raise CacheError(f"value of {len(value)} bytes exceeds max_bytes {self._max_bytes}")
+
+        existing = self._store.pop(key, None)
+        if existing is not None:
+            self._bytes_in_use -= len(existing)
+
+        self._store[key] = value
+        self._bytes_in_use += len(value)
+
+        # Evict LRU until we're under both caps.
+        while self._store and (
+            len(self._store) > self._max_entries or self._bytes_in_use > self._max_bytes
+        ):
+            _, evicted = self._store.popitem(last=False)
+            self._bytes_in_use -= len(evicted)
+
+    def drop(self, key: str) -> bool:
+        """Remove *key* unconditionally. Returns True if a value was present."""
+        existing = self._store.pop(key, None)
+        if existing is None:
+            return False
+        self._bytes_in_use -= len(existing)
+        return True
+
+    def clear(self) -> None:
+        """Empty the cache."""
+        self._store.clear()
+        self._bytes_in_use = 0
+
+
+def apply_delta(cached: bytes, delta: bytes) -> bytes:
+    """Reconstruct the full payload from a cached value + a bsdiff4 delta.
+
+    The delta is opaque to the wire crate; this module fixes the format
+    as **bsdiff4** so the broker and worker agree without a per-message
+    discriminator. The RFC 0001 amendment §"Phase 2 follow-up" documents
+    the choice; revisit if a tensor-aware diff becomes available.
+
+    Raises :class:`DeltaApplyError` when ``bsdiff4`` isn't installed *or*
+    when ``bsdiff4.patch`` raises (most commonly: the delta was computed
+    against a different cache version than the worker holds).
+    """
+    try:
+        import bsdiff4
+    except ImportError as exc:
+        raise DeltaApplyError("bsdiff4 is not installed — install the [worker] extra") from exc
+    try:
+        return bytes(bsdiff4.patch(cached, delta))
+    except Exception as exc:  # bsdiff4 raises various exception types
+        raise DeltaApplyError(f"bsdiff4.patch failed: {exc!r}") from exc


### PR DESCRIPTION
## Summary

Closes #174 **Phase 2 substrate**. The QUIC-handler wiring lands as a follow-up after [#200](https://github.com/zakuro-ai/zakuro/pull/200) (Phase 3 chunk reassembly).

- `zakuro/wire/cache.py`
  - `PayloadCache` — bounded LRU keyed by `EnvelopeV2.cache_key`. Caps configurable via `ZAKURO_CACHE_MAX_ENTRIES` (32) / `ZAKURO_CACHE_MAX_BYTES` (4 GiB).
  - `apply_delta(cached, delta)` — fixed-format **bsdiff4** reconstruction.
  - Errors (`CacheError`, `CacheMissError`, `DeltaApplyError`) all subclass `zakuro.wire.WireError`.
- `pyproject.toml` — `bsdiff4>=1.2.4` added to `[worker]`.
- `docs/rfcs/0001-wire-format-postcard.md` — new "Delta-apply algorithm" subsection documents the format choice + the HMAC-is-the-security-boundary rationale.
- `tests/wire/test_cache.py` — 15 tests covering LRU + bytes-budget eviction, MRU promotion, oversized rejection, env-var defaults, constructor validation, delta round-trip, delta-is-smaller, malformed-delta-raises.

## Wire-format invariants

- v0.1 `Envelope` and v0.2 `EnvelopeV2` without `delta_against` continue to work unchanged.
- `EnvelopeV2 { delta_against: Some(prev_key), .. }` requires the worker to have `prev_key` in cache; otherwise the worker replies with `WorkerUnavailable { reason: "cache_miss" }` and the broker retries with the full payload.
- The delta is not authenticated alone — the envelope's HMAC over `(callable, args, job_id)` covers the delta bytes. A reconstructed payload from the wrong base produces a different HMAC than the broker computed, so `safe_loads` rejects with `HmacMismatchError` before the bytes reach `cloudpickle.loads`.

## Test plan

- [x] `pytest tests/wire/test_cache.py` → 15 passed.
- [x] Full suite: 320 passed.
- [x] `ruff check` / `ruff format --check` clean.
- [x] `mkdocs build --strict` clean.
- [ ] CI green.

## Cross-repo

Paired zc PR required before production rollout: the broker must compute `bsdiff4.diff(prev, new)` and emit it as `EnvelopeV2.callable` with `delta_against = Some(prev_key)`. Until that lands, this code path is dormant — v0.2 envelopes with unset `delta_against` route through the normal full-payload path.
