### PR TITLE
ci: move self-hosted jobs to ARC `cpu` scale set

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   lint-and-test:
-    runs-on: [self-hosted, i9-cpu]
+    runs-on: cpu
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
@@ -37,7 +37,7 @@ jobs:
         run: task test:unit || true
 
   typecheck:
-    runs-on: [self-hosted, i9-cpu]
+    runs-on: cpu
     continue-on-error: true
     steps:
       - uses: actions/checkout@v6
@@ -51,7 +51,7 @@ jobs:
         run: task ci:typecheck || true
 
   rust:
-    runs-on: [self-hosted, i9-cpu]
+    runs-on: cpu
     steps:
       - uses: actions/checkout@v6
       - name: Install Rust toolchain
@@ -69,7 +69,7 @@ jobs:
           RUSTFLAGS: -D warnings
 
   notice:
-    runs-on: [self-hosted, i9-cpu]
+    runs-on: cpu
     steps:
       - uses: actions/checkout@v6
       - name: Set up Python
@@ -82,7 +82,7 @@ jobs:
         run: task notice:check
 
   security:
-    runs-on: [self-hosted, i9-cpu]
+    runs-on: cpu
     continue-on-error: true
     steps:
       - uses: actions/checkout@v6
@@ -123,7 +123,7 @@ jobs:
           exit $FAIL
 
   vulnerability-scan:
-    runs-on: [self-hosted, i9-cpu]
+    runs-on: cpu
     continue-on-error: true
     steps:
       - uses: actions/checkout@v6
@@ -144,7 +144,7 @@ jobs:
           exit-code: "0"
 
   bench:
-    runs-on: [self-hosted, i9-cpu]
+    runs-on: cpu
     if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,7 +42,7 @@ concurrency:
 
 jobs:
   build-and-deploy:
-    runs-on: [self-hosted, i9-cpu]
+    runs-on: cpu
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   create-release:
     if: github.event.workflow_run.conclusion == 'success'
-    runs-on: [self-hosted, i9-cpu]
+    runs-on: cpu
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -43,7 +43,7 @@ concurrency:
 jobs:
   compose-smoke:
     name: docker compose + broker health
-    runs-on: [self-hosted, i9-cpu]
+    runs-on: cpu
     # Report-only on introduction. The first run of this lane caught a real
     # cross-repo issue — `zakuroai/zc@sha256:ec0871a8…` was built against
     # glibc 2.39, which doesn't exist in its runtime base, so the broker

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   publish-pypi:
     if: inputs.confirm_prod_deployed
-    runs-on: [self-hosted, i9-cpu]
+    runs-on: cpu
     environment: release
     steps:
       - uses: actions/checkout@v6
@@ -39,7 +39,7 @@ jobs:
 
   publish-crate:
     if: inputs.confirm_prod_deployed
-    runs-on: [self-hosted, i9-cpu]
+    runs-on: cpu
     environment: release
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   build-and-push:
     if: github.event.workflow_run.conclusion == 'success'
-    runs-on: [self-hosted, i9-cpu]
+    runs-on: cpu
     outputs:
       version: ${{ steps.version.outputs.version }}
       image_digest: ${{ steps.build.outputs.digest }}


### PR DESCRIPTION
## What

Move self-hosted CI jobs from the single static runner to the new **ARC `cpu` scale set** (autoscaling 1→8 ephemeral dind runners on the 20-core `gha-runner-cpu` node, GitOps-managed via actions-runner-controller).

`runs-on: [self-hosted, cpu]` / `[self-hosted, i9-cpu]` → `runs-on: cpu`. `ubuntu-latest` jobs unchanged; no `gpu` jobs affected.

The static `i9-cpu` runner also carries the `cpu` label, so this is a zero-downtime transition — jobs run on ARC or the old runner until the latter is retired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)