### PR TITLE
security: run PR CI on GitHub-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   lint-and-test:
-    runs-on: cpu
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'cpu' }}
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
@@ -37,7 +37,7 @@ jobs:
         run: task test:unit || true
 
   typecheck:
-    runs-on: cpu
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'cpu' }}
     continue-on-error: true
     steps:
       - uses: actions/checkout@v6
@@ -51,7 +51,7 @@ jobs:
         run: task ci:typecheck || true
 
   rust:
-    runs-on: cpu
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'cpu' }}
     steps:
       - uses: actions/checkout@v6
       - name: Install Rust toolchain
@@ -69,7 +69,7 @@ jobs:
           RUSTFLAGS: -D warnings
 
   notice:
-    runs-on: cpu
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'cpu' }}
     steps:
       - uses: actions/checkout@v6
       - name: Set up Python
@@ -82,7 +82,7 @@ jobs:
         run: task notice:check
 
   security:
-    runs-on: cpu
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'cpu' }}
     continue-on-error: true
     steps:
       - uses: actions/checkout@v6
@@ -123,7 +123,7 @@ jobs:
           exit $FAIL
 
   vulnerability-scan:
-    runs-on: cpu
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'cpu' }}
     continue-on-error: true
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,7 +42,7 @@ concurrency:
 
 jobs:
   build-and-deploy:
-    runs-on: cpu
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'cpu' }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -43,7 +43,7 @@ concurrency:
 jobs:
   compose-smoke:
     name: docker compose + broker health
-    runs-on: cpu
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'cpu' }}
     # Report-only on introduction. The first run of this lane caught a real
     # cross-repo issue — `zakuroai/zc@sha256:ec0871a8…` was built against
     # glibc 2.39, which doesn't exist in its runtime base, so the broker


### PR DESCRIPTION
## Why

This is a **public** repository. Pull requests from forks can run arbitrary, attacker-controlled code, and running that code on **self-hosted** runners (the `cpu` label) exposes our internal infrastructure to arbitrary code execution (secrets, network access, persistent runner compromise).

The org just set the **Default** self-hosted runner group to disallow public repositories. As a result, this repo's `pull_request` CI — which currently targets `runs-on: cpu` — can no longer pick up a runner and is **broken** for every PR.

This PR fixes both problems at once: PR-triggered jobs now run on GitHub-hosted `ubuntu-latest`, while `push` / `release` / tag / `workflow_run` / `workflow_dispatch` events keep using the self-hosted `cpu` runners.

## How

Each affected job's `runs-on` was changed to:

```yaml
runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'cpu' }}
```

This evaluates to `ubuntu-latest` only on `pull_request` events and falls back to `cpu` for everything else, so push/release behavior is unchanged.

## Files changed

- **`.github/workflows/ci.yml`** — jobs `lint-and-test`, `typecheck`, `rust`, `notice`, `security`, `vulnerability-scan` (all run on PRs). The push-only `bench` job (`if: github.event_name == 'push' && ...`) was left on `cpu` since it never runs on PRs.
- **`.github/workflows/integration.yml`** — job `compose-smoke` (docker compose + broker health). Uses Docker, which is available on `ubuntu-latest`.
- **`.github/workflows/docs.yml`** — job `build-and-deploy` (only the strict mkdocs PR-preflight step runs on PRs; deploy steps are gated to push/tags).

## Not touched (no `pull_request` trigger — correctly left on `cpu`)

- `release.yml` (`workflow_run` on CI / `release/**`)
- `publish.yml` (`workflow_dispatch`)
- `github-release.yml` (`workflow_run` on Publish Packages)

## Notes

- No PR job in these workflows requires self-hosted GPU/hardware, so none had to be forced back to `cpu`. The only job with a plausible hardware argument — `bench` — is push-only and unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)