### PR TITLE
fix(ci): run public-repo CI on ubuntu-latest, bench manual-only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: ["main", "master", "dev", "feature/**", "release/**"]
   pull_request:
     branches: ["main", "master"]
+  workflow_dispatch:
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -17,7 +18,7 @@ permissions:
 
 jobs:
   lint-and-test:
-    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'cpu' }}
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
@@ -44,7 +45,7 @@ jobs:
         run: task test:unit || true
 
   typecheck:
-    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'cpu' }}
+    runs-on: ubuntu-latest
     continue-on-error: true
     steps:
       - uses: actions/checkout@v6
@@ -65,7 +66,7 @@ jobs:
         run: task ci:typecheck || true
 
   rust:
-    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'cpu' }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - name: Install Rust toolchain
@@ -83,7 +84,7 @@ jobs:
           RUSTFLAGS: -D warnings
 
   notice:
-    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'cpu' }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - name: Set up Python
@@ -103,7 +104,7 @@ jobs:
         run: task notice:check
 
   security:
-    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'cpu' }}
+    runs-on: ubuntu-latest
     continue-on-error: true
     steps:
       - uses: actions/checkout@v6
@@ -148,7 +149,7 @@ jobs:
           exit $FAIL
 
   vulnerability-scan:
-    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'cpu' }}
+    runs-on: ubuntu-latest
     continue-on-error: true
     steps:
       - uses: actions/checkout@v6
@@ -171,8 +172,14 @@ jobs:
           exit-code: "0"
 
   bench:
+    # Runs on the self-hosted `cpu` runner for stable benchmark hardware.
+    # This is a public repo and the org runner group disallows public
+    # repositories (deliberate — avoids the public-repo self-hosted RCE
+    # risk), so auto-running bench on push would queue forever and block
+    # the run. Make it manual-only: dispatch it from an environment where
+    # a `cpu` runner is available.
     runs-on: cpu
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')
+    if: github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@v6
       - name: Set up Python

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -43,7 +43,7 @@ concurrency:
 jobs:
   compose-smoke:
     name: docker compose + broker health
-    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'cpu' }}
+    runs-on: ubuntu-latest
     # Report-only on introduction. The first run of this lane caught a real
     # cross-repo issue — `zakuroai/zc@sha256:ec0871a8…` was built against
     # glibc 2.39, which doesn't exist in its runtime base, so the broker


### PR DESCRIPTION
## Problem

After #217 fixed PR CI, **push/schedule runs on master still queued forever** with no runner assigned, and the daily `integration` lane kept getting cancelled.

Root cause is infrastructure, not the workflow: `zakuro` is a **public** repo, and the org's Default runner group has `allows_public_repositories=false` (the safe default — it prevents the public-repo self-hosted-runner RCE risk flagged in our security audit). But the jobs used `runs-on: cpu` (self-hosted) for non-PR events, so GitHub had no eligible runner.

## Fix (hybrid)

- **CI** — all jobs (`lint-and-test`, `typecheck`, `rust`, `notice`, `security`, `vulnerability-scan`) now run on `ubuntu-latest` for every event.
- **integration** — `compose-smoke` runs on `ubuntu-latest` for every event.
- **bench** — kept on the self-hosted `cpu` runner (needs stable benchmark hardware) but switched to `workflow_dispatch`-only so it no longer auto-queues on push and stalls the run. Dispatch it from an environment that has a `cpu` runner.

We intentionally did **not** flip `allows_public_repositories` to true (would re-introduce the audit's #1 RCE risk).

## Out of scope (flagged)

`publish.yml` (manual dispatch), `release.yml` and `github-release.yml` still target `cpu`. They're the release pipeline (likely needing internal-registry access) and don't block routine CI — left as-is to avoid breaking releases.