### PR TITLE
fix(ci): run docs on ubuntu-latest (public-repo runner fix)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,7 +42,7 @@ concurrency:
 
 jobs:
   build-and-deploy:
-    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'cpu' }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Follow-up to #219. The `docs` workflow still used `runs-on: cpu` for master/tag pushes, so its deploy queued forever (public repo can't use the self-hosted runner group). `mike` deploys to `gh-pages` via `GITHUB_TOKEN`, so it runs fine on `ubuntu-latest`. PR builds (strict mkdocs) were already hosted.