### PR TITLE
fix(integration): bump zc broker image to healthy digest

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -69,7 +69,7 @@ services:
     #
     # To test a local zc build instead:
     #   ZAKURO_BROKER_IMAGE=zakuroai/zc:dev docker compose up
-    image: ${ZAKURO_BROKER_IMAGE:-zakuroai/zc@sha256:ec0871a8bf08875a7c7a67478d6da3804a0d88f4b65bcede4e0c8957d9f8cbd4}
+    image: ${ZAKURO_BROKER_IMAGE:-zakuroai/zc@sha256:ca869fb54442c90b7f0968c30d4eeb30acbe3bf5e9aa035d76b5463d7028f3cd}
     container_name: zakuro-broker
     ports:
       - "9000:9000"


### PR DESCRIPTION
The `integration` lane (report-only, `continue-on-error`) fails because the pinned `zakuroai/zc` broker image (`ec0871a8`) is built against `GLIBC_2.39`, absent from its runtime base, so the broker exits on boot:

```
/usr/local/bin/zc: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found (required by /usr/local/bin/zc)
```

This is a zc-side packaging bug. Docker Hub now has a newer `zakuroai/zc:latest` (`ca869fb5`, 2026-06-11); this bumps the pin to it. The integration lane on this PR will show whether the broker boots and answers `/health`. If green, a follow-up can drop `continue-on-error` to make the lane strict.