### PR TITLE
chore(governance): add standard governance files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Default owners for everything in this repo.
+# Required reviewers for all pull requests (see branch protection).
+* @JeanMaximilienCadic

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,22 @@
+---
+name: Bug report
+about: Report a problem
+title: "[bug] "
+labels: bug
+---
+
+## Description
+
+<!-- What happened? What did you expect? -->
+
+## Steps to reproduce
+
+1.
+2.
+
+## Environment
+
+- Version / commit:
+- OS / platform:
+
+## Additional context

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security report
+    url: mailto:security@zakuro-ai.com
+    about: Report security vulnerabilities privately by email, not as a public issue.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+## What
+
+<!-- What does this PR change? -->
+
+## Why
+
+<!-- Motivation / linked issue. -->
+
+Closes #
+
+## Testing
+
+<!-- How was this verified? Commands run, results observed. -->
+
+## Checklist
+
+- [ ] Lint / format pass locally
+- [ ] Tests added or updated (or N/A with reason)
+- [ ] Docs updated (or N/A)


### PR DESCRIPTION
Adds standard governance files missing from this repo, per the 2026 Q2 repo health audit campaign (see `zakuro-infra/docs/superpowers/specs/2026-06-20-repo-health-audit-design.md`).

Added: .github/CODEOWNERS .github/pull_request_template.md .github/ISSUE_TEMPLATE/config.yml .github/ISSUE_TEMPLATE/bug_report.md

Part of the campaign's governance-hardening pass.